### PR TITLE
support for new data format(PrefixReceivedCount to PfxRcd), fix #16

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -373,7 +373,11 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 				}
 				newCounter(ch, bgpDesc["msgRcvd"], peerData.MsgRcvd, peerLabels...)
 				newCounter(ch, bgpDesc["msgSent"], peerData.MsgSent, peerLabels...)
-				newGauge(ch, bgpDesc["prefixReceivedCount"], peerData.PrefixReceivedCount, peerLabels...)
+				if peerData.PrefixReceivedCount != nil {
+				        newGauge(ch, bgpDesc["prefixReceivedCount"], *peerData.PrefixReceivedCount, peerLabels...)
+				} else {
+				        newGauge(ch, bgpDesc["prefixReceivedCount"], peerData.PfxRcd, peerLabels...)
+				}
 				newGauge(ch, bgpDesc["UptimeSec"], peerData.PeerUptimeMsec*0.001, peerLabels...)
 
 				if *bgpPeerTypes {
@@ -480,7 +484,8 @@ type bgpPeerSession struct {
 	MsgRcvd             float64
 	MsgSent             float64
 	PeerUptimeMsec      float64
-	PrefixReceivedCount float64
+	PrefixReceivedCount *float64
+	PfxRcd              float64
 }
 type bgpAdvertisedRoutes struct {
 	TotalPrefixCounter float64 `json:"totalPrefixCounter"`


### PR DESCRIPTION
It fix #16 .  

If data has `PrefixReceivedCount` key (~ FRR 7.3), use it as `frr_bgp_peer_prefixes_received_count_total` metrics.
Else, use `PfxRcd` .

I tested it FRR 7.3 & 7.4 .