### PR TITLE
support for PfxSnt field

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Flags:
       --collector.bgp.peer-descriptions.plain-text
                                  Use the full text field of the BGP peer description instead of the value of the JSON formatted desc key (default: disabled).
       --collector.bgp.advertised-prefixes
-                                 Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer
-                                 (default: disabled).
+                                 Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer. This is an option for older versions of FRR that don't have PfxSent
+                                 field (default: disabled).
       --web.listen-address=":9342"
                                  Address on which to expose metrics and web interface.
       --web.telemetry-path="/metrics"
@@ -104,6 +104,8 @@ router bgp 64512
 Note, it is recommended to leave this feature disabled as peer descriptions can easily change, resulting in a new time series.
 
 ### BGP: Advertised Prefixes to a Peer
+This is an option for older versions of FRR. If your FRR shows the "PfxSnt" field for Peers in the Established state in the output of "show bgp summary json", you don't need to enable this option.
+
 The number of prefixes advertised to a BGP peer can be enabled (i.e. the `frr_exporter_bgp_prefixes_advertised_count_total` metric) by passing the `--collector.bgp.advertised-prefixes` flag. Please note, FRR does not expose a summary of prefixes advertised to BGP peers, so each peer needs to be queried individually. For example, if 20 BGP peers are configured, 20 `vtysh -c 'sh ip bgp neigh X.X.X.X advertised-routes json'` commands are executed. This can be slow -- the commands are executed in parallel by frr_exporter, but vtysh/FRR seems to execute them in serial. Due to the potential negative performance implications of running `vtysh` for every BGP peer, this metric is disabled by default.
 
 ### BGP: frr_bgp_peer_types_up

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -392,7 +392,6 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 				}
 				newGauge(ch, bgpDesc["prefixReceivedCount"], prefixReceived, peerLabels...)
 
-
 				if *bgpPeerTypes {
 					for _, descKey := range *frrBGPDescKey {
 						if peerDescJSON[peerIP][descKey] != "" {

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -33,7 +33,7 @@ var (
 	frrBGPDescKey         = kingpin.Flag("collector.bgp.peer-types.keys", "Select the keys from the JSON formatted BGP peer description of which the values will be used with the frr_bgp_peer_types_up metric. Supports multiple values (default: type).").Default("type").Strings()
 	bgpPeerDescs          = kingpin.Flag("collector.bgp.peer-descriptions", "Add the value of the desc key from the JSON formatted BGP peer description as a label to peer metrics. (default: disabled).").Default("False").Bool()
 	bgpPeerDescsText      = kingpin.Flag("collector.bgp.peer-descriptions.plain-text", "Use the full text field of the BGP peer description instead of the value of the JSON formatted desc key (default: disabled).").Default("False").Bool()
-	bgpAdvertisedPrefixes = kingpin.Flag("collector.bgp.advertised-prefixes", "Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer (default: disabled).").Default("False").Bool()
+	bgpAdvertisedPrefixes = kingpin.Flag("collector.bgp.advertised-prefixes", "Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer. This is an option for older versions of FRR that don't have PfxSent field (default: disabled).").Default("False").Bool()
 )
 
 // BGPCollector collects BGP metrics, implemented as per prometheus.Collector interface.
@@ -361,7 +361,10 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 				// The labels are "vrf", "afi", "safi", "local_as", "peer", "remote_as"
 				peerLabels := []string{strings.ToLower(vrfName), strings.ToLower(AFI), strings.ToLower(SAFI), localAs, peerIP, strconv.FormatInt(peerData.RemoteAs, 10)}
 
-				if *bgpAdvertisedPrefixes {
+				// In earlier versions of FRR did not expose a summary of advertised prefixes for all peers, but in later versions it can get with PfxSnt field.
+				if peerData.PfxSnt != nil {
+					newGauge(ch, bgpDesc["prefixAdvertisedCount"], *peerData.PfxSnt, peerLabels...)
+				} else if *bgpAdvertisedPrefixes {
 					wgAdvertisedPrefixes.Add(1)
 					go getPeerAdvertisedPrefixes(ch, wgAdvertisedPrefixes, AFI, SAFI, vrfName, peerIP, peerLabels...)
 				}
@@ -388,6 +391,7 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 					prefixReceived = peerData.PfxRcd
 				}
 				newGauge(ch, bgpDesc["prefixReceivedCount"], prefixReceived, peerLabels...)
+
 
 				if *bgpPeerTypes {
 					for _, descKey := range *frrBGPDescKey {
@@ -498,6 +502,7 @@ type bgpPeerSession struct {
 	PeerUptimeMsec      float64
 	PrefixReceivedCount float64
 	PfxRcd              float64
+	PfxSnt              *float64
 }
 type bgpAdvertisedRoutes struct {
 	TotalPrefixCounter float64 `json:"totalPrefixCounter"`


### PR DESCRIPTION
## sumamry

In recent FRRs, there is a `PfxSnt` field in the output of `show bgp summary json`. ( https://github.com/FRRouting/frr/commit/37d4e0dfabcc47e874987d8b7ec27d0f05376705 )  
This field could see only if  peer state is "Established".  

This can be used as `frr_bgp_peer_prefixes_advertised_count_total` metrics.  
`--collector.bgp.advertised-prefixes` option left for old FRRs.

## appendix

example output (FRR `7.3`)  

```json
# show bgp summary json
{
"ipv4Unicast":{
  "routerId":"172.31.0.3",
  "as":4200000003,
  "vrfId":0,
  "vrfName":"default",
  "tableVersion":3192766,
  "ribCount":81,
  "ribMemory":14904,
  "peerCount":2,
  "peerMemory":41856,
  "peerGroupCount":1,
  "peerGroupMemory":64,
  "peers":{
    "ens4f0":{
      "hostname":"edge000a",
      "remoteAs":4200049152,
      "version":4,
      "msgRcvd":10393531,
      "msgSent":10104089,
      "tableVersion":0,
      "outq":0,
      "inq":0,
      "peerUptime":"22w0d20h",
      "peerUptimeMsec":13377756000,
      "peerUptimeEstablishedEpoch":1600936337,
      "prefixReceivedCount":41,
      "pfxRcd":41,
      "pfxSnt":1,
      "state":"Established",
      "connectionsEstablished":3,
      "connectionsDropped":2,
      "idType":"interface"
    },
    "ens4f1":{
      "hostname":"edge000b",
      "remoteAs":4200049153,
      "version":4,
      "msgRcvd":10440881,
      "msgSent":10104070,
      "tableVersion":0,
      "outq":0,
      "inq":0,
      "peerUptime":"22w0d19h",
      "peerUptimeMsec":13377510000,
      "peerUptimeEstablishedEpoch":1600936583,
      "prefixReceivedCount":41,
      "pfxRcd":41,
      "pfxSnt":1,
      "state":"Established",
      "connectionsEstablished":3,
      "connectionsDropped":2,
      "idType":"interface"
    }
  },
  "failedPeers":0,
  "totalPeers":2,
  "dynamicPeers":0,
  "bestPath":{
    "multiPathRelax":"true"
  }
}
}
```