### PR TITLE
bugfix, l2vpn: do not try to unmarshall empty l2vpn evpn summary slice

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -213,7 +213,7 @@ func (c *BGPL2VPNCollector) Collect(ch chan<- prometheus.Metric) {
 	if err != nil {
 		totalBGPL2VPNErrors++
 		bgpL2VPNErrors = append(bgpL2VPNErrors, fmt.Errorf("cannot execute 'show evpn vni json': %s", err))
-	} else {
+	} else if len(jsonBGPL2vpnEvpnSum) != 0 {
 		if err := processBgpL2vpnEvpnSummary(ch, jsonBGPL2vpnEvpnSum); err != nil {
 			totalBGPL2VPNErrors++
 			bgpL2VPNErrors = append(bgpL2VPNErrors, err)


### PR DESCRIPTION
If there is no vrf/vxlan interface/vni configured on the host, the
following command 'show evpn vni json' won't return anything.
Before attempting to unmarshall what is returned, we should check that
the length of the slice is different from 0.
Fixes #29