### PR TITLE
Fix segmentation fault when pathspace option is not provided

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -24,7 +24,7 @@ var (
 	vtyshPath      string
 	vtyshTimeout   time.Duration
 	vtyshSudo      bool
-	vtyshPathspace *string
+	vtyshPathspace string
 )
 
 // CLIHelper is used to populate flags.
@@ -79,7 +79,7 @@ func (e *Exporters) SetVTYSHTimeout(timeout time.Duration) {
 
 // SetVTYSHPathspace sets the frr config path prefix (-N option for vtysh)
 func (e *Exporters) SetVTYSHPathspace(s string) {
-	vtyshPathspace = &s
+	vtyshPathspace = s
 }
 
 // SetVTYSHSudo sets the first command to execute vtysh if sudo is enabled.

--- a/collector/command.go
+++ b/collector/command.go
@@ -23,8 +23,8 @@ func execVtyshCommand(args ...string) ([]byte, error) {
 		executable = vtyshPath
 	}
 
-	if *vtyshPathspace != "" {
-		n_opt := []string{"-N", *vtyshPathspace}
+	if vtyshPathspace != "" {
+		n_opt := []string{"-N", vtyshPathspace}
 		a = append(a, n_opt...)
 	}
 


### PR DESCRIPTION
If I run the exporter without pathspace param, or with the default param,
it will crash:

```
[12:28:29] root@XXX:~# /home/sneubauer/frr_exporter
INFO[0000] Starting frr_exporter (version=, branch=, revision=) on :9342  source="frr_exporter.go:133"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x877e80]

goroutine 36 [running]:
github.com/tynany/frr_exporter/collector.execVtyshCommand(0xc000318e30, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/sneubauer/work/github/syseleven/frr_exporter/collector/command.go:26 +0x120
github.com/tynany/frr_exporter/collector.getOSPFInterface(...)
	/Users/sneubauer/work/github/syseleven/frr_exporter/collector/ospf.go:81
github.com/tynany/frr_exporter/collector.(*OSPFCollector).Collect(0xd07be8, 0xc0000facc0)
	/Users/sneubauer/work/github/syseleven/frr_exporter/collector/ospf.go:56 +0xa9
github.com/tynany/frr_exporter/collector.runCollector(0xc0000facc0, 0xc000328000, 0xc00013c280, 0xc000336000)
	/Users/sneubauer/work/github/syseleven/frr_exporter/collector/collector.go:140 +0xb8
created by github.com/tynany/frr_exporter/collector.(*Exporters).Collect
	/Users/sneubauer/work/github/syseleven/frr_exporter/collector/collector.go:109 +0x1e5
```