### PR TITLE
bugfix: fix nil pointer reference for VTYSHPathspace

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -24,7 +24,7 @@ var (
 	vtyshPath      string
 	vtyshTimeout   time.Duration
 	vtyshSudo      bool
-	vtyshPathspace *string
+	vtyshPathspace string
 )
 
 // CLIHelper is used to populate flags.
@@ -79,7 +79,7 @@ func (e *Exporters) SetVTYSHTimeout(timeout time.Duration) {
 
 // SetVTYSHPathspace sets the frr config path prefix (-N option for vtysh)
 func (e *Exporters) SetVTYSHPathspace(s string) {
-	vtyshPathspace = &s
+	vtyshPathspace = s
 }
 
 // SetVTYSHSudo sets the first command to execute vtysh if sudo is enabled.

--- a/collector/command.go
+++ b/collector/command.go
@@ -23,8 +23,8 @@ func execVtyshCommand(args ...string) ([]byte, error) {
 		executable = vtyshPath
 	}
 
-	if *vtyshPathspace != "" {
-		n_opt := []string{"-N", *vtyshPathspace}
+	if vtyshPathspace != "" {
+		n_opt := []string{"-N", vtyshPathspace}
 		a = append(a, n_opt...)
 	}
 


### PR DESCRIPTION
Collector goroutines are crashing if there is no VTYSHPathspace
declared. This is because the pointer was passed along instead of the
string.


### Steps to reproduce (v0.2.15)
Run frr-exporter
`./frr-exporter
`
Get metrics
`curl http://127.0.0.1:9342/metrics`

Stacktrace
```
~/.../src/frr_exporter >>> ./frr_exporter                                                                                      ±[master]
INFO[0000] Starting frr_exporter (version=, branch=, revision=) on :9342  source="frr_exporter.go:126"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x87c200]

goroutine 34 [running]:
github.com/tynany/frr_exporter/collector.execVtyshCommand(0xc00005ce30, 0x2, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0)
        /home/fdomain/go/src/frr_exporter/collector/command.go:26 +0x120
github.com/tynany/frr_exporter/collector.getOSPFInterface(...)
        /home/fdomain/go/src/frr_exporter/collector/ospf.go:81
github.com/tynany/frr_exporter/collector.(*OSPFCollector).Collect(0xd0cde0, 0xc000078de0)
        /home/fdomain/go/src/frr_exporter/collector/ospf.go:56 +0xa9
github.com/tynany/frr_exporter/collector.runCollector(0xc000078de0, 0xc000014500, 0xc00007a2d0, 0xc0000bb190)
        /home/fdomain/go/src/frr_exporter/collector/collector.go:140 +0xb8
created by github.com/tynany/frr_exporter/collector.(*Exporters).Collect
        /home/fdomain/go/src/frr_exporter/collector/collector.go:109 +0x1e5

```