### PR TITLE
promu: bump version to 0.12.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PROMU_VERSION := 0.6.1
+PROMU_VERSION := 0.12.0
 
 setup_promu:
 	curl -s -L https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).linux-amd64.tar.gz | tar -xvzf - 


### PR DESCRIPTION
https://github.com/prometheus/promu/releases/tag/v0.12.0