### PR TITLE
Format code with goimports use consistent newlines

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -48,7 +48,7 @@ func getBGPDesc() map[string]*prometheus.Desc {
 
 	if *bgpPeerDescs {
 		bgpPeerLabels = append(bgpLabels, "peer", "peer_as", "peer_desc")
-}
+	}
 	bgpPeerMetricPrefix := "bgp_peer"
 
 	return map[string]*prometheus.Desc{

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -76,7 +76,6 @@ func (c *bgpCollector) Update(ch chan<- prometheus.Metric) error {
 
 // NewBGP6Collector collects BGPv6 metrics, implemented as per the Collector interface.
 func NewBGP6Collector(logger log.Logger) (Collector, error) {
-
 	return &bgpCollector{logger: logger, descriptions: getBGPDesc(), afi: "ipv6"}, nil
 }
 
@@ -87,7 +86,6 @@ type bgpL2VPNCollector struct {
 
 // NewBGPL2VPNCollector collects BGP L2VPN metrics, implemented as per the Collector interface.
 func NewBGPL2VPNCollector(logger log.Logger) (Collector, error) {
-
 	return &bgpL2VPNCollector{logger: logger, descriptions: getBGPL2VPNDesc()}, nil
 }
 
@@ -176,7 +174,6 @@ func collectBGP(ch chan<- prometheus.Metric, AFI string, logger log.Logger, desc
 
 func getBGPSummary(AFI string, SAFI string) ([]byte, error) {
 	args := []string{"-c", fmt.Sprintf("show bgp vrf all %s %s summary json", AFI, SAFI)}
-
 	return execVtyshCommand(args...)
 }
 

--- a/collector/ospf.go
+++ b/collector/ospf.go
@@ -50,7 +50,6 @@ func (c *ospfCollector) Update(ch chan<- prometheus.Metric) error {
 
 func getOSPFInterface() ([]byte, error) {
 	args := []string{"-c", "show ip ospf vrf all interface json"}
-
 	return execVtyshCommand(args...)
 }
 

--- a/collector/pim.go
+++ b/collector/pim.go
@@ -27,10 +27,11 @@ type pimCollector struct {
 func NewPIMCollector(logger log.Logger) (Collector, error) {
 	return &pimCollector{logger: logger, descriptions: getPIMDesc()}, nil
 }
+
 func getPIMDesc() map[string]*prometheus.Desc {
 	labels := []string{"vrf"}
-
 	neighborLabels := append(labels, "iface", "neighbor")
+
 	return map[string]*prometheus.Desc{
 		"neighborCount": colPromDesc(pimSubsystem, "neighbor_count_total", "Number of neighbors detected", labels),
 		"upTime":        colPromDesc(pimSubsystem+"_neighbor", "uptime_seconds", "How long has the peer been up.", neighborLabels),
@@ -39,7 +40,6 @@ func getPIMDesc() map[string]*prometheus.Desc {
 
 // Collect implemented as per the Collector interface
 func (c *pimCollector) Update(ch chan<- prometheus.Metric) error {
-
 	jsonPIMNeighbors, err := getPIMNeighbors()
 	if err != nil {
 		return fmt.Errorf("cannot get pim neighbors: %s", err)
@@ -53,7 +53,6 @@ func (c *pimCollector) Update(ch chan<- prometheus.Metric) error {
 
 func getPIMNeighbors() ([]byte, error) {
 	args := []string{"-c", "show ip pim vrf all neighbor json"}
-
 	return execVtyshCommand(args...)
 }
 

--- a/collector/vrrp.go
+++ b/collector/vrrp.go
@@ -18,8 +18,7 @@ const (
 
 var (
 	vrrpSubsystem = "vrrp"
-
-	vrrpStates = []string{vrrpStatusInitialize, vrrpStatusMaster, vrrpStatusBackup}
+	vrrpStates    = []string{vrrpStatusInitialize, vrrpStatusMaster, vrrpStatusBackup}
 )
 
 func init() {
@@ -86,7 +85,6 @@ func (c *vrrpCollector) Update(ch chan<- prometheus.Metric) error {
 
 func getVRRPInfo() ([]byte, error) {
 	args := []string{"-c", "show vrrp json"}
-
 	return execVtyshCommand(args...)
 }
 
@@ -105,7 +103,6 @@ func processVRRPInfo(ch chan<- prometheus.Metric, jsonVRRPInfo []byte, desc map[
 }
 
 func processInstance(ch chan<- prometheus.Metric, proto string, vrid int, iface string, instance VrrpInstanceInfo, vrrpDesc map[string]*prometheus.Desc) {
-
 	vrrpLabels := []string{proto, strconv.Itoa(vrid), iface, instance.Subinterface}
 
 	for _, state := range vrrpStates {


### PR DESCRIPTION
Run
```
goimports -w .
```

Ensure that there is a newline between each function. Remove newlines around single lines to group them visually.

Maybe you could add a check to the CI to ensure the code is formatted nicely on every PR.