### PR TITLE
Fix getting the BGP peer description

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -341,7 +341,7 @@ func getBGPPeerDesc(logger log.Logger) (map[string]map[string]string, map[string
 	descJSON := make(map[string]map[string]string)
 	descText := make(map[string]string)
 
-	output, err := execVtyshCommand("-c", "show run bgpd")
+	output, err := execVtyshCommand("-c", "show bgp neighbors json")
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Commit 120ff2ab06679060640610f2765633c672f8c944 changed `getBGPPeerDesc` to parse the JSON output from the `vtysh` command `show bgp neighbors` instead of `show run bgpd`, but forgot to update the `vtysh` command.

Successfully tested in our environment.

It would be nice if there were test cases that cover this kind of issue.

Closes: https://github.com/tynany/frr_exporter/issues/52