### PR TITLE
Do not use else after return

### DIFF
--- a/collector/bfd.go
+++ b/collector/bfd.go
@@ -41,10 +41,9 @@ func (c *bfdCollector) Update(ch chan<- prometheus.Metric) error {
 	jsonBFDInterface, err := executeBFDCommand(cmd)
 	if err != nil {
 		return err
-	} else {
-		if err = processBFDPeers(ch, jsonBFDInterface, c.descriptions); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonBFDInterface), err)
-		}
+	}
+	if err = processBFDPeers(ch, jsonBFDInterface, c.descriptions); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonBFDInterface), err)
 	}
 	return nil
 }

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -107,11 +107,12 @@ func (c *bgpL2VPNCollector) Update(ch chan<- prometheus.Metric) error {
 	jsonBGPL2vpnEvpnSum, err := executeZebraCommand(cmd)
 	if err != nil {
 		return err
-
-	} else if len(jsonBGPL2vpnEvpnSum) != 0 {
-		if err := processBgpL2vpnEvpnSummary(ch, jsonBGPL2vpnEvpnSum, c.descriptions); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonBGPL2vpnEvpnSum), err)
-		}
+	}
+	if len(jsonBGPL2vpnEvpnSum) == 0 {
+		return nil
+	}
+	if err := processBgpL2vpnEvpnSummary(ch, jsonBGPL2vpnEvpnSum, c.descriptions); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonBGPL2vpnEvpnSum), err)
 	}
 	return nil
 }
@@ -159,10 +160,9 @@ func collectBGP(ch chan<- prometheus.Metric, AFI string, logger log.Logger, desc
 	jsonBGPSum, err := executeBGPCommand(cmd)
 	if err != nil {
 		return err
-	} else {
-		if err := processBGPSummary(ch, jsonBGPSum, AFI, SAFI, logger, desc); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonBGPSum), err)
-		}
+	}
+	if err := processBGPSummary(ch, jsonBGPSum, AFI, SAFI, logger, desc); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonBGPSum), err)
 	}
 	return nil
 }

--- a/collector/ospf.go
+++ b/collector/ospf.go
@@ -41,10 +41,9 @@ func (c *ospfCollector) Update(ch chan<- prometheus.Metric) error {
 	jsonOSPFInterface, err := executeOSPFCommand(cmd)
 	if err != nil {
 		return err
-	} else {
-		if err = processOSPFInterface(ch, jsonOSPFInterface, c.descriptions); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonOSPFInterface), err)
-		}
+	}
+	if err = processOSPFInterface(ch, jsonOSPFInterface, c.descriptions); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonOSPFInterface), err)
 	}
 	return nil
 }

--- a/collector/pim.go
+++ b/collector/pim.go
@@ -44,10 +44,9 @@ func (c *pimCollector) Update(ch chan<- prometheus.Metric) error {
 	jsonPIMNeighbors, err := executePIMCommand(cmd)
 	if err != nil {
 		return err
-	} else {
-		if err := processPIMNeighbors(ch, jsonPIMNeighbors, c.logger, c.descriptions); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonPIMNeighbors), err)
-		}
+	}
+	if err := processPIMNeighbors(ch, jsonPIMNeighbors, c.logger, c.descriptions); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonPIMNeighbors), err)
 	}
 	return nil
 }

--- a/collector/vrrp.go
+++ b/collector/vrrp.go
@@ -75,10 +75,9 @@ func (c *vrrpCollector) Update(ch chan<- prometheus.Metric) error {
 	jsonVRRPInfo, err := executeVRRPCommand(cmd)
 	if err != nil {
 		return err
-	} else {
-		if err := processVRRPInfo(ch, jsonVRRPInfo, c.descriptions); err != nil {
-			return cmdOutputProcessError(cmd, string(jsonVRRPInfo), err)
-		}
+	}
+	if err := processVRRPInfo(ch, jsonVRRPInfo, c.descriptions); err != nil {
+		return cmdOutputProcessError(cmd, string(jsonVRRPInfo), err)
 	}
 	return nil
 }


### PR DESCRIPTION
Putting an `else` right after a `return` will increase the indentation level. Remove the `else` to keep the error-free code path in the top level.