### PR TITLE
fix missing bgp l2vpn descriptions

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -88,14 +88,15 @@ func NewBGPL2VPNCollector(logger log.Logger) (Collector, error) {
 }
 
 func getBGPL2VPNDesc() map[string]*prometheus.Desc {
+	bgpDesc := getBGPDesc()
 	labels := []string{"vni", "type", "vxlanIf", "tenantVrf"}
 	metricPrefix := "bgp_l2vpn_evpn"
 
-	return map[string]*prometheus.Desc{
-		"numMacs":        colPromDesc(metricPrefix, "mac_count_total", "Number of known MAC addresses", labels),
-		"numArpNd":       colPromDesc(metricPrefix, "arp_nd_count_total", "Number of ARP / ND entries", labels),
-		"numRemoteVteps": colPromDesc(metricPrefix, "remote_vtep_count_total", "Number of known remote VTEPs. A value of -1 indicates a non-integer output from FRR, such as n/a.", labels),
-	}
+	bgpDesc["numMacs"] = colPromDesc(metricPrefix, "mac_count_total", "Number of known MAC addresses", labels)
+	bgpDesc["numArpNd"] = colPromDesc(metricPrefix, "arp_nd_count_total", "Number of ARP / ND entries", labels)
+	bgpDesc["numRemoteVteps"] = colPromDesc(metricPrefix, "remote_vtep_count_total", "Number of known remote VTEPs. A value of -1 indicates a non-integer output from FRR, such as n/a.", labels)
+
+	return bgpDesc
 }
 
 // Update implemented as per the Collector interface.


### PR DESCRIPTION
- Fix https://github.com/tynany/frr_exporter/issues/56.

Before:
```
# ./frr_exporter --collector.bgpl2vpn --log.level=debug
level=info ts=2021-12-14T07:52:42.965Z caller=frr_exporter.go:65 msg="Starting frr_exporter" version="(version=, branch=, revision=)"
level=info ts=2021-12-14T07:52:42.965Z caller=frr_exporter.go:66 msg="Build context" build_context="(go=go1.17, user=, date=)"
level=info ts=2021-12-14T07:52:42.966Z caller=frr_exporter.go:67 msg="Listening on address" address=:9342
level=info ts=2021-12-14T07:52:42.966Z caller=tls_config.go:191 msg="TLS is disabled." http2=false
level=debug ts=2021-12-14T07:52:44.403Z caller=collector.go:124 msg="collector succeeded" name=bgp duration_seconds=0.000391316
level=debug ts=2021-12-14T07:52:44.403Z caller=collector.go:124 msg="collector succeeded" name=ospf duration_seconds=0.002571372
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x60 pc=0x772dfd]
```

After:
```
# ./frr_exporter --collector.bgpl2vpn --log.level=debug
level=info ts=2021-12-14T07:52:19.939Z caller=frr_exporter.go:65 msg="Starting frr_exporter" version="(version=, branch=, revision=)"
level=info ts=2021-12-14T07:52:19.940Z caller=frr_exporter.go:66 msg="Build context" build_context="(go=go1.17, user=, date=)"
level=info ts=2021-12-14T07:52:19.940Z caller=frr_exporter.go:67 msg="Listening on address" address=:9342
level=info ts=2021-12-14T07:52:19.940Z caller=tls_config.go:191 msg="TLS is disabled." http2=false
level=debug ts=2021-12-14T07:52:21.465Z caller=collector.go:124 msg="collector succeeded" name=bgp duration_seconds=0.000385306
level=debug ts=2021-12-14T07:52:21.466Z caller=collector.go:124 msg="collector succeeded" name=ospf duration_seconds=0.003171557
level=debug ts=2021-12-14T07:52:21.466Z caller=collector.go:124 msg="collector succeeded" name=bgpl2vpn duration_seconds=0.001180232
level=debug ts=2021-12-14T07:52:21.657Z caller=collector.go:124 msg="collector succeeded" name=bfd duration_seconds=0.19444143
```

@bdrung @dswarbrick please let me know if you have time to review this small PR. Thanks

This really highlights the need for E2E tests. I have some time off coming up and will work on something.