### PR TITLE
Fixup linting error in CI; add linting to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,14 @@ cd ${GOPATH}/src/github.com/prometheus/frr_exporter
 go build
 ```
 
+This project uses https://golangci-lint.run in GitHub Actions. You can lint your code locally
+before submitting a PR by following the installation instructions at 
+https://golangci-lint.run/usage/install/ and run prior to submitting changes:
+
+```
+golangci-lint run 
+```
+
 ## TODO
 
  - Collector and main tests

--- a/internal/frrsockets/frrsockets.go
+++ b/internal/frrsockets/frrsockets.go
@@ -50,10 +50,7 @@ func executeCmd(socketPath, cmd string, timeout time.Duration) ([]byte, error) {
 		return buf.Bytes(), err
 	}
 	defer func(conn *net.UnixConn) {
-		err := conn.Close()
-		if err != nil {
-			// ignored
-		}
+		_ = conn.Close()
 	}(conn)
 
 	if err = conn.SetDeadline(time.Now().Add(timeout)); err != nil {


### PR DESCRIPTION
My previous PR failed linting in CI and it was not noticed until after it was merged to master. 

This fixes the linting error and adds instructions to the README on how to run the linting tool locally before submitting a PR.