### PR TITLE
Add Docker Upload Action + build arm64 images

### DIFF
--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -1,4 +1,4 @@
-name: bandersnatch_docker_upload
+name: frr_exporter_docker_upload
 
 on:
   push:

--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -1,0 +1,43 @@
+name: bandersnatch_docker_upload
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: created
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Check + set version tag
+        run:
+          echo "GIT_TAG=$(git describe --candidates=0 --tags 2> /dev/null || echo
+          latest_non_release)" >> $GITHUB_ENV
+
+      - name: Build and push image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: tynany/frr_exporter:latest,tynany/frr_exporter:${{ env.GIT_TAG }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}

--- a/.github/workflows/docker_upload.yml
+++ b/.github/workflows/docker_upload.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
- Upload on every push to main for latest
- Also tag the release version when a new release is made
  - i.e. when you release a very the Git tag name is used for docker image tagging too - e.g. v1.1.1
- Also build a arm64/aarch64 build (e.g. for raspberry pi / apple M1)

This is in use for many project I contribute to.

## Why do I want this?

- I'd like to run your frr_exporter on arm64/aarch64 boxes
  - On my raspberry pi in my RV is one example

## What you'll need to do to use this
- Before merging add two secrets to you GitHub repo:
  - DOCKERHUB_USERNAME
  - DOCKERHUB_SECRET
    - This secret need to be a dockerhub secret you generate here: https://hub.docker.com/settings/security

How to add GitHub secrets: https://github.com/Azure/actions-workflow-samples/blob/master/assets/create-secrets-for-GitHub-workflows.md

Merge away and it should upload :)