### PR TITLE
Use filepath.Join in place of simple string concatenation

### DIFF
--- a/internal/frrsockets/frrsockets.go
+++ b/internal/frrsockets/frrsockets.go
@@ -18,27 +18,27 @@ func NewConnection(dirPath string, timeout time.Duration) *Connection {
 }
 
 func (c Connection) ExecBGPCmd(cmd string) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+"/bgpd.vty"), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, "bgpd.vty"), cmd, c.timeout)
 }
 
 func (c Connection) ExecOSPFCmd(cmd string) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+"/ospfd.vty"), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, "ospfd.vty"), cmd, c.timeout)
 }
 
 func (c Connection) ExecOSPFMultiInstanceCmd(cmd string, instanceID int) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+fmt.Sprintf("/ospfd-%d.vty", instanceID)), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, fmt.Sprintf("ospfd-%d.vty", instanceID)), cmd, c.timeout)
 }
 
 func (c Connection) ExecPIMCmd(cmd string) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+"/pimd.vty"), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, "pimd.vty"), cmd, c.timeout)
 }
 
 func (c Connection) ExecVRRPCmd(cmd string) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+"/vrrpd.vty"), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, "vrrpd.vty"), cmd, c.timeout)
 }
 
 func (c Connection) ExecZebraCmd(cmd string) ([]byte, error) {
-	return executeCmd(filepath.Clean(c.dirPath+"/zebra.vty"), cmd, c.timeout)
+	return executeCmd(filepath.Join(c.dirPath, "zebra.vty"), cmd, c.timeout)
 }
 
 func executeCmd(socketPath, cmd string, timeout time.Duration) ([]byte, error) {

--- a/internal/frrsockets/frrsockets_test.go
+++ b/internal/frrsockets/frrsockets_test.go
@@ -32,7 +32,7 @@ func TestExecuteCmd(t *testing.T) {
 			panic(err)
 		}
 
-		conn.Write([]byte(expected + "\x00"))
+		_, _ = conn.Write([]byte(expected + "\x00"))
 	}()
 
 	// Allow socket listener goroutine to settle


### PR DESCRIPTION
filepath.Join is the preferred way to assemble paths elegantly, and the result is cleaned by filepath.Clean anyway.