### PR TITLE
remove-metric-frr_up

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -31,7 +31,6 @@ var (
 	frrDesc   = map[string]*prometheus.Desc{
 		"frrScrapeDuration": promDesc("scrape_duration_seconds", "Time it took for a collector's scrape to complete.", frrLabels),
 		"frrCollectorUp":    promDesc("collector_up", "Whether the collector's last scrape was successful (1 = successful, 0 = unsuccessful).", frrLabels),
-		"frrUp":             promDesc("up", "Whether FRR is currently up.", nil),
 	}
 
 	socketDirPath = kingpin.Flag("frr.socket.dir-path", "Path of of the localstatedir containing each daemon's Unix socket.").Default("/var/run/frr").String()


### PR DESCRIPTION
Removing the `frr_up` metric as it provides little value. The `frr_collector_up` can be used in its place. If this exporter is being used to determine the state of FRR, we should create a new collector that runs an arbitrary command such as `show version` to validate the state of FRR.

https://github.com/tynany/frr_exporter/issues/95