### PR TITLE
Implement support for reading bfdd.vty socket directly

### DIFF
--- a/collector/command.go
+++ b/collector/command.go
@@ -18,6 +18,13 @@ var (
 	frrVTYSHOptions = kingpin.Flag("frr.vtysh.options", "Additional options passed to vtysh.").Default("").String()
 )
 
+func executeBFDCommand(cmd string) ([]byte, error) {
+	if *vtyshEnable {
+		return execVtyshCommand(cmd)
+	}
+	return socketConn.ExecBFDCmd(cmd)
+}
+
 func executeBGPCommand(cmd string) ([]byte, error) {
 	if *vtyshEnable {
 		return execVtyshCommand(cmd)
@@ -56,12 +63,6 @@ func executeVRRPCommand(cmd string) ([]byte, error) {
 	}
 	return socketConn.ExecVRRPCmd(cmd)
 
-}
-
-func executeBFDCommand(cmd string) ([]byte, error) {
-	// to do: work out how to interact with the bfdd.vty Unix socket:
-	// % [BFD] Unknown command: show bfd peers json
-	return execVtyshCommand(cmd)
 }
 
 func execVtyshCommand(vtyshCmd string) ([]byte, error) {

--- a/internal/frrsockets/frrsockets_test.go
+++ b/internal/frrsockets/frrsockets_test.go
@@ -68,8 +68,18 @@ func mockSocket(socketPath string, socketData string) {
 		panic(err)
 	}
 
-	_, err = conn.Write([]byte(socketData + "\x00"))
-	if err != nil {
+	// If initial command is 'enable', send expected response and wait for next command.
+	if string(cmd[:7]) == "enable\x00" {
+		if _, err := conn.Write([]byte{0, 0, 0, 0}); err != nil {
+			panic(err)
+		}
+
+		if _, err := conn.Read(cmd); err != nil {
+			panic(err)
+		}
+	}
+
+	if _, err := conn.Write([]byte(socketData + "\x00")); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
`show bfd peers` requires vty session to be in 'enable' mode. Since `vtysh` defaults to 'enable' mode anyway, follow the same method.

Closes: #100