### PR TITLE
Adopt structured logging using log/slog

### DIFF
--- a/collector/bfd.go
+++ b/collector/bfd.go
@@ -2,8 +2,8 @@ package collector
 
 import (
 	"encoding/json"
+	"log/slog"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -16,12 +16,12 @@ func init() {
 }
 
 type bfdCollector struct {
-	logger       log.Logger
+	logger       *slog.Logger
 	descriptions map[string]*prometheus.Desc
 }
 
 // NewBFDCollector collects BFD metrics, implemented as per the Collector interface.
-func NewBFDCollector(logger log.Logger) (Collector, error) {
+func NewBFDCollector(logger *slog.Logger) (Collector, error) {
 	return &bfdCollector{logger: logger, descriptions: getBFDDesc()}, nil
 }
 

--- a/collector/ospf.go
+++ b/collector/ospf.go
@@ -3,11 +3,11 @@ package collector
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -21,13 +21,13 @@ func init() {
 }
 
 type ospfCollector struct {
-	logger       log.Logger
+	logger       *slog.Logger
 	descriptions map[string]*prometheus.Desc
 	instanceIDs  []int
 }
 
 // NewOSPFCollector  collects OSPF metrics, implemented as per the Collector interface.
-func NewOSPFCollector(logger log.Logger) (Collector, error) {
+func NewOSPFCollector(logger *slog.Logger) (Collector, error) {
 	var instanceIDs []int
 	if len(*frrOSPFInstances) > 0 {
 		// FRR Exporter does not support multi-instance when using `vtysh` to interface with FRR

--- a/collector/vrrp.go
+++ b/collector/vrrp.go
@@ -2,10 +2,10 @@ package collector
 
 import (
 	"encoding/json"
+	"log/slog"
 	"strconv"
 	"strings"
 
-	"github.com/go-kit/log"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,12 +46,12 @@ type VrrpInstanceStats struct {
 }
 
 type vrrpCollector struct {
-	logger       log.Logger
+	logger       *slog.Logger
 	descriptions map[string]*prometheus.Desc
 }
 
 // NewVRRPCollector collects VRRP metrics, implemented as per the Collector interface.
-func NewVRRPCollector(logger log.Logger) (Collector, error) {
+func NewVRRPCollector(logger *slog.Logger) (Collector, error) {
 	return &vrrpCollector{logger: logger, descriptions: getVRRPDesc()}, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,10 @@ go 1.22
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0
-	github.com/go-kit/log v0.2.1
 	github.com/prometheus/client_golang v1.20.3
 	github.com/prometheus/client_model v0.6.1
 	github.com/prometheus/common v0.59.1
-	github.com/prometheus/exporter-toolkit v0.12.0
+	github.com/prometheus/exporter-toolkit v0.13.0
 )
 
 require (
@@ -16,7 +15,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/jpillora/backoff v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,6 @@ github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
-github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
-github.com/go-logfmt/logfmt v0.5.1 h1:otpy5pqBCBZ1ng9RQ0dPu4PN7ba75Y/aA+UpowDyNVA=
-github.com/go-logfmt/logfmt v0.5.1/go.mod h1:WYhtIu8zTZfxdn5+rREduYbwxfcBr/Vr6KEVveWlfTs=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -44,8 +40,8 @@ github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p
 github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/common v0.59.1 h1:LXb1quJHWm1P6wq/U824uxYi4Sg0oGvNeUm1z5dJoX0=
 github.com/prometheus/common v0.59.1/go.mod h1:GpWM7dewqmVYcd7SmRaiWVe9SSqjf0UrwnYnpEZNuT0=
-github.com/prometheus/exporter-toolkit v0.12.0 h1:DkE5RcEZR3lQA2QD5JLVQIf41dFKNsVMXFhgqcif7fo=
-github.com/prometheus/exporter-toolkit v0.12.0/go.mod h1:fQH0KtTn0yrrS0S82kqppRjDDiwMfIQUwT+RBRRhwUc=
+github.com/prometheus/exporter-toolkit v0.13.0 h1:lmA0Q+8IaXgmFRKw09RldZmZdnvu9wwcDLIXGmTPw1c=
+github.com/prometheus/exporter-toolkit v0.13.0/go.mod h1:2uop99EZl80KdXhv/MxVI2181fMcwlsumFOqBecGkG0=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=


### PR DESCRIPTION
Prometheus and its associated libraries are moving away from go-kit/log, and instead will use the built-in log/slog from the Go standard library, which is available since Go 1.21.

prometheus/exporter-toolkit v0.13.0 implemented a non-backwards-compatible change to the web.ListenAndServe() function (among others), and now expects to be supplied a *slog.Logger.

For the end user, this change is minimal. Logs may have a subtly different appearance, but are still in logfmt, so log parsers such as Loki should not trip up on this.