### PR TITLE
Upgrade to frr 10.1.2 to fix CVE-2024-45491

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN make setup_promu
 RUN ./promu build
 RUN ls -lah
 
-FROM quay.io/frrouting/frr:10.1.0
+FROM quay.io/frrouting/frr:10.1.2
 WORKDIR /app
 COPY --from=0 /go/src/github.com/tynany/frr_exporter/frr_exporter .
 EXPOSE 9342


### PR DESCRIPTION
Bump the patch version to 10.1.2 to include bug fix with CVEs (from 40 to 2)

Following is the scene result from trivy.

```
Total: 40 (UNKNOWN: 4, LOW: 6, MEDIUM: 19, HIGH: 9, CRITICAL: 2)

┌──────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│       Library        │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├──────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3           │ CVE-2024-6119  │ MEDIUM   │ fixed  │ 3.1.6-r2          │ 3.1.7-r0      │ openssl: Possible denial of service in X.509 name checks    │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6119                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9143  │ LOW      │        │                   │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│                      │                │          │        │                   │               │ memory access                                               │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├──────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libexpat             │ CVE-2024-45491 │ CRITICAL │        │ 2.6.2-r0          │ 2.6.3-r0      │ libexpat: Integer Overflow or Wraparound                    │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45491                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-45492 │          │        │                   │               │ libexpat: integer overflow                                  │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45492                  │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-45490 │ HIGH     │        │                   │               │ libexpat: Negative Length Parsing Vulnerability in libexpat │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-45490                  │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-50602 │ MEDIUM   │        │                   │ 2.6.4-r0      │ libexpat: expat: DoS via XML_ResumeParser                   │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-50602                  │
├──────────────────────┼────────────────┤          │        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3              │ CVE-2024-6119  │          │        │ 3.1.6-r2          │ 3.1.7-r0      │ openssl: Possible denial of service in X.509 name checks    │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6119                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9143  │ LOW      │        │                   │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB   │
│                      │                │          │        │                   │               │ memory access                                               │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                   │
├──────────────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ pyc                  │ CVE-2024-6232  │ HIGH     │        │ 3.11.9-r0         │ 3.11.10-r0    │ python: cpython: tarfile: ReDos via excessive backtracking  │
│                      │                │          │        │                   │               │ while parsing header values                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6232                   │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-7592  │          │        │                   │               │ cpython: python: Uncontrolled CPU resource consumption when │
│                      │                │          │        │                   │               │ in http.cookies module                                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-7592                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2023-27043 │ MEDIUM   │        │                   │               │ python: Parsing errors in email/_parseaddr.py lead to       │
│                      │                │          │        │                   │               │ incorrect value in email address...                         │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-27043                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-6923  │          │        │                   │               │ cpython: python: email module doesn't properly quotes       │
│                      │                │          │        │                   │               │ newlines in email headers, allowing...                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6923                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-8088  │          │        │                   │ 3.11.9-r1     │ python: cpython: Iterating over a malicious ZIP file may    │
│                      │                │          │        │                   │               │ lead to Denial...                                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-8088                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9287  │          │        │                   │ 3.11.11-r0    │ python: Virtual environment (venv) activation scripts don't │
│                      │                │          │        │                   │               │ quote paths                                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9287                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-4032  │ LOW      │        │                   │ 3.11.10-r0    │ python: incorrect IPv4 and IPv6 private ranges              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4032                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2015-2104  │ UNKNOWN  │        │                   │               │ Rejected reason: DO NOT USE THIS CANDIDATE NUMBER.          │
│                      │                │          │        │                   │               │ ConsultIDs: none. Reason: This...                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2015-2104                   │
├──────────────────────┼────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│ python3              │ CVE-2024-6232  │ HIGH     │        │                   │               │ python: cpython: tarfile: ReDos via excessive backtracking  │
│                      │                │          │        │                   │               │ while parsing header values                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6232                   │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-7592  │          │        │                   │               │ cpython: python: Uncontrolled CPU resource consumption when │
│                      │                │          │        │                   │               │ in http.cookies module                                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-7592                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2023-27043 │ MEDIUM   │        │                   │               │ python: Parsing errors in email/_parseaddr.py lead to       │
│                      │                │          │        │                   │               │ incorrect value in email address...                         │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-27043                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-6923  │          │        │                   │               │ cpython: python: email module doesn't properly quotes       │
│                      │                │          │        │                   │               │ newlines in email headers, allowing...                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6923                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-8088  │          │        │                   │ 3.11.9-r1     │ python: cpython: Iterating over a malicious ZIP file may    │
│                      │                │          │        │                   │               │ lead to Denial...                                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-8088                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9287  │          │        │                   │ 3.11.11-r0    │ python: Virtual environment (venv) activation scripts don't │
│                      │                │          │        │                   │               │ quote paths                                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9287                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-4032  │ LOW      │        │                   │ 3.11.10-r0    │ python: incorrect IPv4 and IPv6 private ranges              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4032                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2015-2104  │ UNKNOWN  │        │                   │               │ Rejected reason: DO NOT USE THIS CANDIDATE NUMBER.          │
│                      │                │          │        │                   │               │ ConsultIDs: none. Reason: This...                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2015-2104                   │
├──────────────────────┼────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│ python3-pyc          │ CVE-2024-6232  │ HIGH     │        │                   │               │ python: cpython: tarfile: ReDos via excessive backtracking  │
│                      │                │          │        │                   │               │ while parsing header values                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6232                   │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-7592  │          │        │                   │               │ cpython: python: Uncontrolled CPU resource consumption when │
│                      │                │          │        │                   │               │ in http.cookies module                                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-7592                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2023-27043 │ MEDIUM   │        │                   │               │ python: Parsing errors in email/_parseaddr.py lead to       │
│                      │                │          │        │                   │               │ incorrect value in email address...                         │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-27043                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-6923  │          │        │                   │               │ cpython: python: email module doesn't properly quotes       │
│                      │                │          │        │                   │               │ newlines in email headers, allowing...                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6923                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-8088  │          │        │                   │ 3.11.9-r1     │ python: cpython: Iterating over a malicious ZIP file may    │
│                      │                │          │        │                   │               │ lead to Denial...                                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-8088                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9287  │          │        │                   │ 3.11.11-r0    │ python: Virtual environment (venv) activation scripts don't │
│                      │                │          │        │                   │               │ quote paths                                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9287                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-4032  │ LOW      │        │                   │ 3.11.10-r0    │ python: incorrect IPv4 and IPv6 private ranges              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4032                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2015-2104  │ UNKNOWN  │        │                   │               │ Rejected reason: DO NOT USE THIS CANDIDATE NUMBER.          │
│                      │                │          │        │                   │               │ ConsultIDs: none. Reason: This...                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2015-2104                   │
├──────────────────────┼────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│ python3-pycache-pyc0 │ CVE-2024-6232  │ HIGH     │        │                   │               │ python: cpython: tarfile: ReDos via excessive backtracking  │
│                      │                │          │        │                   │               │ while parsing header values                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6232                   │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-7592  │          │        │                   │               │ cpython: python: Uncontrolled CPU resource consumption when │
│                      │                │          │        │                   │               │ in http.cookies module                                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-7592                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2023-27043 │ MEDIUM   │        │                   │               │ python: Parsing errors in email/_parseaddr.py lead to       │
│                      │                │          │        │                   │               │ incorrect value in email address...                         │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-27043                  │
│                      ├────────────────┤          │        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-6923  │          │        │                   │               │ cpython: python: email module doesn't properly quotes       │
│                      │                │          │        │                   │               │ newlines in email headers, allowing...                      │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-6923                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-8088  │          │        │                   │ 3.11.9-r1     │ python: cpython: Iterating over a malicious ZIP file may    │
│                      │                │          │        │                   │               │ lead to Denial...                                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-8088                   │
│                      ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-9287  │          │        │                   │ 3.11.11-r0    │ python: Virtual environment (venv) activation scripts don't │
│                      │                │          │        │                   │               │ quote paths                                                 │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9287                   │
│                      ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│                      │ CVE-2024-4032  │ LOW      │        │                   │ 3.11.10-r0    │ python: incorrect IPv4 and IPv6 private ranges              │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-4032                   │
│                      ├────────────────┼──────────┤        │                   │               ├─────────────────────────────────────────────────────────────┤
│                      │ CVE-2015-2104  │ UNKNOWN  │        │                   │               │ Rejected reason: DO NOT USE THIS CANDIDATE NUMBER.          │
│                      │                │          │        │                   │               │ ConsultIDs: none. Reason: This...                           │
│                      │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2015-2104                   │
└──────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
```


Result after 10.1.2, the alpine version was upgraded to 3.19.4
```
Total: 2 (UNKNOWN: 0, LOW: 2, MEDIUM: 0, HIGH: 0, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├────────────┼───────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2024-9143 │ LOW      │ fixed  │ 3.1.7-r0          │ 3.1.7-r1      │ openssl: Low-level invalid GF(2^m) parameters lead to OOB │
│            │               │          │        │                   │               │ memory access                                             │
│            │               │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-9143                 │
├────────────┤               │          │        │                   │               │                                                           │
│ libssl3    │               │          │        │                   │               │                                                           │
│            │               │          │        │                   │               │                                                           │
│            │               │          │        │                   │               │                                                           │
└────────────┴───────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
```