### PR TITLE
Add OSPF LSA counter metrics

### DIFF
--- a/collector/ospf_test.go
+++ b/collector/ospf_test.go
@@ -10,50 +10,146 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-var expectedOSPFMetrics = map[string]float64{
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,vrf=default}":                       0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,vrf=default}":                       1,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,vrf=red}":                           0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,vrf=red}":                           1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,vrf=default}":            0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,vrf=default}":            1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,vrf=red}":                0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,vrf=red}":                1,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,instance=1,vrf=default}":            0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,instance=1,vrf=default}":            1,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,instance=1,vrf=red}":                0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,instance=1,vrf=red}":                1,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,instance=2,vrf=default}":            0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,instance=2,vrf=default}":            1,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,instance=2,vrf=red}":                0,
-	"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,instance=2,vrf=red}":                1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,instance=1,vrf=default}": 0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,instance=1,vrf=default}": 1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,instance=1,vrf=red}":     0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,instance=1,vrf=red}":     1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,instance=2,vrf=default}": 0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,instance=2,vrf=default}": 1,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,instance=2,vrf=red}":     0,
-	"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,instance=2,vrf=red}":     1,
-}
+var (
+	expectedOSPFIfaceMetrics = map[string]float64{
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,vrf=default}":                       0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,vrf=default}":                       1,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,vrf=red}":                           0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,vrf=red}":                           1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,vrf=default}":            0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,vrf=default}":            1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,vrf=red}":                0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,vrf=red}":                1,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,instance=1,vrf=default}":            0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,instance=1,vrf=default}":            1,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,instance=1,vrf=red}":                0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,instance=1,vrf=red}":                1,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp1,instance=2,vrf=default}":            0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp2,instance=2,vrf=default}":            1,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp3,instance=2,vrf=red}":                0,
+		"frr_ospf_neighbors{area=0.0.0.0,iface=swp4,instance=2,vrf=red}":                1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,instance=1,vrf=default}": 0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,instance=1,vrf=default}": 1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,instance=1,vrf=red}":     0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,instance=1,vrf=red}":     1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp1,instance=2,vrf=default}": 0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp2,instance=2,vrf=default}": 1,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp3,instance=2,vrf=red}":     0,
+		"frr_ospf_neighbor_adjacencies{area=0.0.0.0,iface=swp4,instance=2,vrf=red}":     1,
+	}
+	expectedOSPFMetrics = map[string]float64{
+		"frr_ospf_lsa_external_counter{vrf=default}":                            109,
+		"frr_ospf_lsa_as_opaque_counter{vrf=default}":                           0,
+		"frr_ospf_area_lsa_number{area=0.0.0.0,vrf=default}":                    17,
+		"frr_ospf_area_lsa_network_number{area=0.0.0.0,vrf=default}":            1,
+		"frr_ospf_area_lsa_summary_number{area=0.0.0.0,vrf=default}":            0,
+		"frr_ospf_area_lsa_asbr_number{area=0.0.0.0,vrf=default}":               0,
+		"frr_ospf_area_lsa_nssa_number{area=0.0.0.0,vrf=default}":               0,
+		"frr_ospf_lsa_external_counter{instance=1,vrf=default}":                 109,
+		"frr_ospf_lsa_as_opaque_counter{instance=1,vrf=default}":                0,
+		"frr_ospf_area_lsa_number{area=0.0.0.0,instance=1,vrf=default}":         17,
+		"frr_ospf_area_lsa_network_number{area=0.0.0.0,instance=1,vrf=default}": 1,
+		"frr_ospf_area_lsa_summary_number{area=0.0.0.0,instance=1,vrf=default}": 0,
+		"frr_ospf_area_lsa_asbr_number{area=0.0.0.0,instance=1,vrf=default}":    0,
+		"frr_ospf_area_lsa_nssa_number{area=0.0.0.0,instance=1,vrf=default}":    0,
+		"frr_ospf_lsa_external_counter{instance=2,vrf=default}":                 109,
+		"frr_ospf_lsa_as_opaque_counter{instance=2,vrf=default}":                0,
+		"frr_ospf_area_lsa_number{area=0.0.0.0,instance=2,vrf=default}":         17,
+		"frr_ospf_area_lsa_network_number{area=0.0.0.0,instance=2,vrf=default}": 1,
+		"frr_ospf_area_lsa_summary_number{area=0.0.0.0,instance=2,vrf=default}": 0,
+		"frr_ospf_area_lsa_asbr_number{area=0.0.0.0,instance=2,vrf=default}":    0,
+		"frr_ospf_area_lsa_nssa_number{area=0.0.0.0,instance=2,vrf=default}":    0,
+	}
+)
 
 func TestProcessOSPFInterface(t *testing.T) {
 	ospfInterfaceSum := readTestFixture(t, "show_ip_ospf_vrf_all_interface.json")
 
-	ch := make(chan prometheus.Metric, len(expectedOSPFMetrics))
-	if err := processOSPFInterface(ch, ospfInterfaceSum, getOSPFDesc(), 0); err != nil {
+	*frrOSPFInstances = ""
+	ch := make(chan prometheus.Metric, len(expectedOSPFIfaceMetrics))
+	if err := processOSPFInterface(ch, ospfInterfaceSum, getOSPFIfaceDesc(), 0); err != nil {
 		t.Errorf("error calling processOSPFInterface ipv4unicast: %s", err)
 	}
 
 	// test for OSPF multiple instances
 	*frrOSPFInstances = "1,2"
 	for i := 1; i <= 2; i++ {
-		if err := processOSPFInterface(ch, ospfInterfaceSum, getOSPFDesc(), i); err != nil {
+		if err := processOSPFInterface(ch, ospfInterfaceSum, getOSPFIfaceDesc(), i); err != nil {
 			t.Errorf("error calling processOSPFInterface ipv4unicast: %s", err)
 		}
 	}
 	close(ch)
 
+	// Create a map of following format:
+	//   key: metric_name{labelname:labelvalue,...}
+	//   value: metric value
+	gotMetrics := make(map[string]float64)
+
+	for {
+		msg, more := <-ch
+		if !more {
+			break
+		}
+		metric := &dto.Metric{}
+		if err := msg.Write(metric); err != nil {
+			t.Errorf("error writing metric: %s", err)
+		}
+
+		var labels []string
+		for _, label := range metric.GetLabel() {
+			labels = append(labels, fmt.Sprintf("%s=%s", label.GetName(), label.GetValue()))
+		}
+
+		var value float64
+		if metric.GetCounter() != nil {
+			value = metric.GetCounter().GetValue()
+		} else if metric.GetGauge() != nil {
+			value = metric.GetGauge().GetValue()
+		}
+
+		re, err := regexp.Compile(`.*fqName: "(.*)", help:.*`)
+		if err != nil {
+			t.Errorf("could not compile regex: %s", err)
+		}
+		metricName := re.FindStringSubmatch(msg.Desc().String())[1]
+
+		gotMetrics[fmt.Sprintf("%s{%s}", metricName, strings.Join(labels, ","))] = value
+	}
+
+	for metricName, metricVal := range gotMetrics {
+		if expectedMetricVal, ok := expectedOSPFIfaceMetrics[metricName]; ok {
+			if expectedMetricVal != metricVal {
+				t.Errorf("metric %s expected value %v got %v", metricName, expectedMetricVal, metricVal)
+			}
+		} else {
+			t.Errorf("unexpected metric: %s : %v", metricName, metricVal)
+		}
+	}
+
+	for expectedMetricName, expectedMetricVal := range expectedOSPFIfaceMetrics {
+		if _, ok := gotMetrics[expectedMetricName]; !ok {
+			t.Errorf("missing metric: %s value %v", expectedMetricName, expectedMetricVal)
+		}
+	}
+}
+
+func TestProcessOSPF(t *testing.T) {
+	ospfSum := readTestFixture(t, "show_ip_ospf_vrf_all.json")
+
+	*frrOSPFInstances = ""
+	ch := make(chan prometheus.Metric, len(expectedOSPFMetrics))
+	if err := processOSPF(ch, ospfSum, getOSPFDesc(), 0); err != nil {
+		t.Errorf("error calling processOSPF ipv4unicast: %s", err)
+	}
+
+	// test for OSPF multiple instances
+	*frrOSPFInstances = "1,2"
+	for i := 1; i <= 2; i++ {
+		if err := processOSPF(ch, ospfSum, getOSPFDesc(), i); err != nil {
+			t.Errorf("error calling processOSPF ipv4unicast: %s", err)
+		}
+	}
+	close(ch)
 	// Create a map of following format:
 	//   key: metric_name{labelname:labelvalue,...}
 	//   value: metric value
@@ -105,4 +201,5 @@ func TestProcessOSPFInterface(t *testing.T) {
 			t.Errorf("missing metric: %s value %v", expectedMetricName, expectedMetricVal)
 		}
 	}
+
 }

--- a/collector/testdata/show_ip_ospf_vrf_all.json
+++ b/collector/testdata/show_ip_ospf_vrf_all.json
@@ -1,0 +1,53 @@
+{
+    "default": {
+        "vrfName": "default",
+        "vrfId": 0,
+        "routerId": "0.0.56.137",
+        "tosRoutesOnly": true,
+        "rfc2328Conform": true,
+        "rfc1583Compatibility": true,
+        "spfScheduleDelayMsecs": 2000,
+        "holdtimeMinMsecs": 5000,
+        "holdtimeMaxMsecs": 20000,
+        "holdtimeMultplier": 1,
+        "spfLastExecutedMsecs": 492410115,
+        "spfLastDurationMsecs": 0,
+        "lsaMinIntervalMsecs": 5000,
+        "lsaMinArrivalMsecs": 5000,
+        "writeMultiplier": 20,
+        "refreshTimerMsecs": 10000,
+        "maximumPaths": 256,
+        "preference": 110,
+        "asbrRouter": "injectingExternalRoutingInformation",
+        "lsaExternalCounter": 109,
+        "lsaExternalChecksum": 3680599,
+        "lsaAsopaqueCounter": 0,
+        "lsaAsOpaqueChecksum": 0,
+        "attachedAreaCounter": 1,
+        "areas": {
+            "0.0.0.0": {
+                "backbone": true,
+                "areaIfTotalCounter": 7,
+                "areaIfActiveCounter": 7,
+                "nbrFullAdjacentCounter": 3,
+                "authentication": "authenticationNone",
+                "spfExecutedCounter": 43,
+                "lsaNumber": 17,
+                "lsaRouterNumber": 16,
+                "lsaRouterChecksum": 539897,
+                "lsaNetworkNumber": 1,
+                "lsaNetworkChecksum": 6844,
+                "lsaSummaryNumber": 0,
+                "lsaSummaryChecksum": 0,
+                "lsaAsbrNumber": 0,
+                "lsaAsbrChecksum": 0,
+                "lsaNssaNumber": 0,
+                "lsaNssaChecksum": 0,
+                "lsaOpaqueLinkNumber": 0,
+                "lsaOpaqueLinkChecksum": 0,
+                "lsaOpaqueAreaNumber": 0,
+                "lsaOpaqueAreaChecksum": 0
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR add OSPF instance LSA counter as-well as area LSA counter information metrics.

The following metrics are added:
* `frr_ospf_area_lsa_asbr_number`
* `frr_ospf_area_lsa_network_number`
* `frr_ospf_area_lsa_nssa_number`
* `frr_ospf_area_lsa_number`
* `frr_ospf_area_lsa_summary_number`
* `frr_ospf_lsa_as_opaque_counter`
* `frr_ospf_lsa_external_counter`

We are encountering several problems in production, where routers installed the wrong LSAs because of some database inconsistencies. These metrics should help detect these problems and give indications of what is happening in the network.