### PR TITLE
Adding BGP Peer Nexthop Interface

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -269,7 +269,7 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 					}
 
 					if *bgpNextHopInterface {
-						var familyMap = map[string]map[string]bgpNextHopInterfaces{
+						familyMap := map[string]map[string]bgpNextHopInterfaces{
 							"ipv4": bgpNextHop[vrfName].IPv4,
 							"ipv6": bgpNextHop[vrfName].IPv6,
 						}

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -23,7 +23,7 @@ var (
 	bgpPeerDescsText            = kingpin.Flag("collector.bgp.peer-descriptions.plain-text", "Use the full text field of the BGP peer description instead of the value of the JSON formatted desc key (default: disabled).").Default("False").Bool()
 	bgpAdvertisedPrefixes       = kingpin.Flag("collector.bgp.advertised-prefixes", "Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer. This is an option for older versions of FRR that don't have PfxSent field (default: disabled).").Default("False").Bool()
 	bgpAcceptedFilteredPrefixes = kingpin.Flag("collector.bgp.accepted-filtered-prefixes", "Enable retrieval of accepted and filtered BGP prefix counts (default: disabled).").Default("False").Bool()
-	bgpNextHopInterface         = kingpin.Flag("collector.bgp.next-hop-interface", "Add next-hop interface to bgp peer state metric (default: disabled).").Default("False").Bool()
+	bgpNextHopInterface         = kingpin.Flag("collector.bgp.next-hop-interface", "Adds the peer's next-hop interface label. (default: disabled).").Default("False").Bool()
 )
 
 func init() {

--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -23,6 +23,7 @@ var (
 	bgpPeerDescsText            = kingpin.Flag("collector.bgp.peer-descriptions.plain-text", "Use the full text field of the BGP peer description instead of the value of the JSON formatted desc key (default: disabled).").Default("False").Bool()
 	bgpAdvertisedPrefixes       = kingpin.Flag("collector.bgp.advertised-prefixes", "Enables the frr_exporter_bgp_prefixes_advertised_count_total metric which exports the number of advertised prefixes to a BGP peer. This is an option for older versions of FRR that don't have PfxSent field (default: disabled).").Default("False").Bool()
 	bgpAcceptedFilteredPrefixes = kingpin.Flag("collector.bgp.accepted-filtered-prefixes", "Enable retrieval of accepted and filtered BGP prefix counts (default: disabled).").Default("False").Bool()
+	bgpNextHopInterface         = kingpin.Flag("collector.bgp.next-hop-interface", "Add next-hop interface to bgp peer state metric (default: disabled).").Default("False").Bool()
 )
 
 func init() {
@@ -57,6 +58,10 @@ func getBGPDesc() map[string]*prometheus.Desc {
 
 	if *bgpPeerGroups {
 		bgpPeerLabels = append(bgpPeerLabels, "peer_group")
+	}
+
+	if *bgpNextHopInterface {
+		bgpPeerLabels = append(bgpPeerLabels, "nexthop_interface")
 	}
 
 	return map[string]*prometheus.Desc{
@@ -210,6 +215,14 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 		}
 	}
 
+	var bgpNextHop map[string]bgpNextHop
+	if *bgpNextHopInterface {
+		bgpNextHop, err = getBGPNexthop()
+		if err != nil {
+			return err
+		}
+	}
+
 	peerTypes := make(map[string]map[string]float64)
 	wg := &sync.WaitGroup{}
 	for vrfName, vrfData := range jsonMap {
@@ -253,6 +266,24 @@ func processBGPSummary(ch chan<- prometheus.Metric, jsonBGPSum []byte, AFI strin
 
 					if *bgpPeerGroups {
 						peerLabels = append(peerLabels, peerDesc[vrfName].BGPNeighbors[peerIP].PeerGroup)
+					}
+
+					if *bgpNextHopInterface {
+						var familyMap = map[string]map[string]bgpNextHopInterfaces{
+							"ipv4": bgpNextHop[vrfName].IPv4,
+							"ipv6": bgpNextHop[vrfName].IPv6,
+						}
+						key := strings.ToLower(AFI)
+						if nexthop, ok := familyMap[key][peerIP]; !ok {
+							logger.Warn("BGP next hop not found", "afi", AFI, "peer", peerIP)
+							peerLabels = append(peerLabels, "unknown")
+						} else {
+							if len(nexthop.Nexthops) > 0 {
+								peerLabels = append(peerLabels, nexthop.Nexthops[0].InterfaceName)
+							} else {
+								peerLabels = append(peerLabels, "unknown")
+							}
+						}
 					}
 
 					// In earlier versions of FRR did not expose a summary of advertised prefixes for all peers, but in later versions it can get with PfxSnt field.
@@ -475,4 +506,31 @@ type bgpVRF struct {
 type bgpNeighbor struct {
 	Desc      string `json:"nbrDesc"`
 	PeerGroup string `json:"peerGroup"`
+}
+
+type bgpNextHopInterfaces struct {
+	Nexthops []struct {
+		InterfaceName string `json:"interfaceName"`
+	} `json:"nexthops"`
+}
+
+type bgpNextHop struct {
+	IPv4 map[string]bgpNextHopInterfaces
+	IPv6 map[string]bgpNextHopInterfaces
+}
+
+func getBGPNexthop() (map[string]bgpNextHop, error) {
+	output, err := executeBGPCommand("show ip bgp vrf all nexthop json")
+	if err != nil {
+		return nil, err
+	}
+	return processBGPNexthop(output)
+}
+
+func processBGPNexthop(output []byte) (map[string]bgpNextHop, error) {
+	bgpNextHop := make(map[string]bgpNextHop)
+	if err := json.Unmarshal([]byte(output), &bgpNextHop); err != nil {
+		return nil, err
+	}
+	return bgpNextHop, nil
 }

--- a/collector/bgp_test.go
+++ b/collector/bgp_test.go
@@ -1,89 +1,110 @@
 package collector
 
 import (
-	"fmt"
+	"log/slog"
 	"reflect"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 )
 
-var (
-	expectedBGPMetrics = map[string]float64{
+func runBGPSummaryTest(t *testing.T, fixture string, afi string, processFn func(chan<- prometheus.Metric, []byte, string, string, *slog.Logger, map[string]*prometheus.Desc) error, getDesc func() map[string]*prometheus.Desc, expected map[string]float64) {
+	// load the raw JSON
+	data := readTestFixture(t, fixture)
+
+	// enough buffer for instance=0 plus instances 1,2
+	ch := make(chan prometheus.Metric, len(expected)*3)
+
+	if err := processFn(ch, data, afi, "", nil, getDesc()); err != nil {
+		t.Errorf("error calling processFn %s: %s", afi, err)
+	}
+	close(ch)
+
+	gotMetrics := collectMetrics(t, ch)
+	compareMetrics(t, gotMetrics, expected)
+}
+
+func TestProcessBGPSummary(t *testing.T) {
+	expectedIpv4 := map[string]float64{
 		"frr_bgp_peer_groups_count_total{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                           0.0,
 		"frr_bgp_peer_groups_count_total{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                               0.0,
-		"frr_bgp_peer_groups_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                           0.0,
-		"frr_bgp_peer_groups_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                               0.0,
 		"frr_bgp_peer_groups_memory_bytes{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                          0.0,
 		"frr_bgp_peer_groups_memory_bytes{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                              0.0,
-		"frr_bgp_peer_groups_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                          0.0,
-		"frr_bgp_peer_groups_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                              0.0,
 		"frr_bgp_peer_message_received_total{afi=ipv4,local_as=64512,peer=192.168.0.2,peer_as=64513,safi=unicast,vrf=default}":        100.0,
 		"frr_bgp_peer_message_received_total{afi=ipv4,local_as=64512,peer=192.168.0.3,peer_as=64514,safi=unicast,vrf=default}":        0.0,
 		"frr_bgp_peer_message_received_total{afi=ipv4,local_as=64612,peer=192.168.1.2,peer_as=64613,safi=unicast,vrf=red}":            100.0,
 		"frr_bgp_peer_message_received_total{afi=ipv4,local_as=64612,peer=192.168.1.3,peer_as=64614,safi=unicast,vrf=red}":            200.0,
-		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":            29285.0,
-		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":            0.0,
-		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":              29285.0,
-		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":              0.0,
 		"frr_bgp_peer_message_sent_total{afi=ipv4,local_as=64512,peer=192.168.0.2,peer_as=64513,safi=unicast,vrf=default}":            100.0,
 		"frr_bgp_peer_message_sent_total{afi=ipv4,local_as=64512,peer=192.168.0.3,peer_as=64514,safi=unicast,vrf=default}":            0.0,
 		"frr_bgp_peer_message_sent_total{afi=ipv4,local_as=64612,peer=192.168.1.2,peer_as=64613,safi=unicast,vrf=red}":                100.0,
 		"frr_bgp_peer_message_sent_total{afi=ipv4,local_as=64612,peer=192.168.1.3,peer_as=64614,safi=unicast,vrf=red}":                200.0,
-		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":                29285.0,
-		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":                0.0,
-		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":                  29285.0,
-		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":                  0.0,
 		"frr_bgp_peer_prefixes_received_count_total{afi=ipv4,local_as=64512,peer=192.168.0.2,peer_as=64513,safi=unicast,vrf=default}": 0.0,
 		"frr_bgp_peer_prefixes_received_count_total{afi=ipv4,local_as=64512,peer=192.168.0.3,peer_as=64514,safi=unicast,vrf=default}": 2.0,
 		"frr_bgp_peer_prefixes_received_count_total{afi=ipv4,local_as=64612,peer=192.168.1.2,peer_as=64613,safi=unicast,vrf=red}":     2.0,
 		"frr_bgp_peer_prefixes_received_count_total{afi=ipv4,local_as=64612,peer=192.168.1.3,peer_as=64614,safi=unicast,vrf=red}":     0.0,
-		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":     1.0,
-		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":     0.0,
-		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":       1.0,
-		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":       0.0,
 		"frr_bgp_peers_count_total{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                                 2.0,
 		"frr_bgp_peers_count_total{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                                     2.0,
-		"frr_bgp_peers_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                                 2.0,
-		"frr_bgp_peers_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                     2.0,
 		"frr_bgp_peers_memory_bytes{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                                39936.0,
 		"frr_bgp_peers_memory_bytes{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                                    39936.0,
-		"frr_bgp_peers_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                                59904.0,
-		"frr_bgp_peers_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                    59904.0,
 		"frr_bgp_peer_state{afi=ipv4,local_as=64512,peer=192.168.0.2,peer_as=64513,safi=unicast,vrf=default}":                         1.0,
 		"frr_bgp_peer_state{afi=ipv4,local_as=64512,peer=192.168.0.3,peer_as=64514,safi=unicast,vrf=default}":                         0.0,
 		"frr_bgp_peer_state{afi=ipv4,local_as=64612,peer=192.168.1.2,peer_as=64613,safi=unicast,vrf=red}":                             1.0,
 		"frr_bgp_peer_state{afi=ipv4,local_as=64612,peer=192.168.1.3,peer_as=64614,safi=unicast,vrf=red}":                             0.0,
-		"frr_bgp_peer_state{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":                             1.0,
-		"frr_bgp_peer_state{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":                             0.0,
-		"frr_bgp_peer_state{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":                               1.0,
-		"frr_bgp_peer_state{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":                               0.0,
 		"frr_bgp_peer_uptime_seconds{afi=ipv4,local_as=64512,peer=192.168.0.2,peer_as=64513,safi=unicast,vrf=default}":                10.0,
 		"frr_bgp_peer_uptime_seconds{afi=ipv4,local_as=64512,peer=192.168.0.3,peer_as=64514,safi=unicast,vrf=default}":                0.0,
 		"frr_bgp_peer_uptime_seconds{afi=ipv4,local_as=64612,peer=192.168.1.2,peer_as=64613,safi=unicast,vrf=red}":                    20.0,
 		"frr_bgp_peer_uptime_seconds{afi=ipv4,local_as=64612,peer=192.168.1.3,peer_as=64614,safi=unicast,vrf=red}":                    0.0,
-		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":                    8465643000.0,
-		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":                    0.0,
-		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":                      87873.0,
-		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":                      0.0,
 		"frr_bgp_rib_count_total{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                                   1.0,
 		"frr_bgp_rib_count_total{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                                       0.0,
-		"frr_bgp_rib_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                                   3.0,
-		"frr_bgp_rib_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                       3.0,
 		"frr_bgp_rib_memory_bytes{afi=ipv4,local_as=64512,safi=unicast,vrf=default}":                                                  64.0,
 		"frr_bgp_rib_memory_bytes{afi=ipv4,local_as=64612,safi=unicast,vrf=red}":                                                      0.0,
-		"frr_bgp_rib_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                                  456.0,
-		"frr_bgp_rib_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                      456.0,
 		"frr_bgp_peer_state{afi=ipv4,local_as=64512,peer=192.168.0.4,peer_as=64515,safi=unicast,vrf=default}":                         2.0,
 		"frr_bgp_peer_message_sent_total{afi=ipv4,local_as=64512,peer=192.168.0.4,peer_as=64515,safi=unicast,vrf=default}":            0.0,
 		"frr_bgp_peer_prefixes_received_count_total{afi=ipv4,local_as=64512,peer=192.168.0.4,peer_as=64515,safi=unicast,vrf=default}": 2.0,
 		"frr_bgp_peer_uptime_seconds{afi=ipv4,local_as=64512,peer=192.168.0.4,peer_as=64515,safi=unicast,vrf=default}":                0.0,
 		"frr_bgp_peer_message_received_total{afi=ipv4,local_as=64512,peer=192.168.0.4,peer_as=64515,safi=unicast,vrf=default}":        0.0,
 	}
-	expectedBgpL2vpnMetrics = map[string]float64{
+	runBGPSummaryTest(t, "show_bgp_vrf_all_ipv4_summary.json", "ipv4", processBGPSummary, getBGPDesc, expectedIpv4)
+
+	expectedIpv6 := map[string]float64{
+		"frr_bgp_peers_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                            59904.0,
+		"frr_bgp_peers_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                59904.0,
+		"frr_bgp_peers_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                             2.0,
+		"frr_bgp_peers_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                 2.0,
+		"frr_bgp_peer_groups_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                       0.0,
+		"frr_bgp_peer_groups_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                           0.0,
+		"frr_bgp_peer_groups_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                      0.0,
+		"frr_bgp_peer_groups_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                          0.0,
+		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":        29285.0,
+		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":        0.0,
+		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":          29285.0,
+		"frr_bgp_peer_message_received_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":          0.0,
+		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":            29285.0,
+		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":            0.0,
+		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":              29285.0,
+		"frr_bgp_peer_message_sent_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":              0.0,
+		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}": 1.0,
+		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}": 0.0,
+		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":   1.0,
+		"frr_bgp_peer_prefixes_received_count_total{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":   0.0,
+		"frr_bgp_peer_state{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":                         1.0,
+		"frr_bgp_peer_state{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":                         0.0,
+		"frr_bgp_peer_state{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":                           1.0,
+		"frr_bgp_peer_state{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":                           0.0,
+		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64512,peer=fd00::1,peer_as=64513,safi=unicast,vrf=default}":                8465643000.0,
+		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64512,peer=fd00::5,peer_as=64514,safi=unicast,vrf=default}":                0.0,
+		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64612,peer=fd00::101,peer_as=64613,safi=unicast,vrf=red}":                  87873.0,
+		"frr_bgp_peer_uptime_seconds{afi=ipv6,local_as=64612,peer=fd00::105,peer_as=64614,safi=unicast,vrf=red}":                  0.0,
+		"frr_bgp_rib_count_total{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                               3.0,
+		"frr_bgp_rib_count_total{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                   3.0,
+		"frr_bgp_rib_memory_bytes{afi=ipv6,local_as=64512,safi=unicast,vrf=default}":                                              456.0,
+		"frr_bgp_rib_memory_bytes{afi=ipv6,local_as=64612,safi=unicast,vrf=red}":                                                  456.0,
+	}
+	runBGPSummaryTest(t, "show_bgp_vrf_all_ipv6_summary.json", "ipv6", processBGPSummary, getBGPDesc, expectedIpv6)
+}
+
+func TestProcessBgpL2vpnEvpnSummary(t *testing.T) {
+	expected := map[string]float64{
 		"frr_bgp_l2vpn_evpn_arp_nd_count_total{tenantVrf=default,type=L2,vni=172192,vxlanIf=ONTEP1_172192}":      23.000000,
 		"frr_bgp_l2vpn_evpn_arp_nd_count_total{tenantVrf=default,type=L2,vni=174374,vxlanIf=ONTEP1_174374}":      0.000000,
 		"frr_bgp_l2vpn_evpn_mac_count_total{tenantVrf=default,type=L2,vni=172192,vxlanIf=ONTEP1_172192}":         0.000000,
@@ -91,67 +112,15 @@ var (
 		"frr_bgp_l2vpn_evpn_remote_vtep_count_total{tenantVrf=default,type=L2,vni=172192,vxlanIf=ONTEP1_172192}": -1.000000,
 		"frr_bgp_l2vpn_evpn_remote_vtep_count_total{tenantVrf=default,type=L2,vni=174374,vxlanIf=ONTEP1_174374}": 1.000000,
 	}
-)
 
-func prepareMetrics(ch chan prometheus.Metric, t *testing.T) map[string]float64 {
-	gotMetrics := make(map[string]float64)
-
-	for {
-		msg, more := <-ch
-		if !more {
-			break
-		}
-		metric := &dto.Metric{}
-		if err := msg.Write(metric); err != nil {
-			t.Errorf("error writing metric: %s", err)
-		}
-
-		var labels []string
-		for _, label := range metric.GetLabel() {
-			labels = append(labels, fmt.Sprintf("%s=%s", label.GetName(), label.GetValue()))
-		}
-
-		var value float64
-		if metric.GetCounter() != nil {
-			value = metric.GetCounter().GetValue()
-		} else if metric.GetGauge() != nil {
-			value = metric.GetGauge().GetValue()
-		}
-
-		re, err := regexp.Compile(`.*fqName: "(.*)", help:.*`)
-		if err != nil {
-			t.Errorf("could not compile regex: %s", err)
-		}
-		metricName := re.FindStringSubmatch(msg.Desc().String())[1]
-
-		gotMetrics[fmt.Sprintf("%s{%s}", metricName, strings.Join(labels, ","))] = value
-	}
-	return gotMetrics
-}
-
-func TestProcessBGPSummary(t *testing.T) {
-	ch := make(chan prometheus.Metric, 1024)
-	if err := processBGPSummary(ch, readTestFixture(t, "show_bgp_vrf_all_ipv4_summary.json"), "ipv4", "", nil, getBGPDesc()); err != nil {
-		t.Errorf("error calling processBGPSummary ipv4unicast: %s", err)
-	}
-	if err := processBGPSummary(ch, readTestFixture(t, "show_bgp_vrf_all_ipv6_summary.json"), "ipv6", "", nil, getBGPDesc()); err != nil {
-		t.Errorf("error calling processBGPSummary ipv6unicast: %s", err)
-	}
-	close(ch)
-
-	gotMetrics := prepareMetrics(ch, t)
-	compareMetrics(t, gotMetrics, expectedBGPMetrics)
-}
-
-func TestProcessBgpL2vpnEvpnSummary(t *testing.T) {
 	ch := make(chan prometheus.Metric, 1024)
 	if err := processBgpL2vpnEvpnSummary(ch, readTestFixture(t, "show_evpn_vni.json"), getBGPL2VPNDesc()); err != nil {
 		t.Errorf("error calling processBgpL2vpnEvpnSummary: %s", err)
 	}
 	close(ch)
 
-	gotMetrics := prepareMetrics(ch, t)
-	compareMetrics(t, gotMetrics, expectedBgpL2vpnMetrics)
+	gotMetrics := collectMetrics(t, ch)
+	compareMetrics(t, gotMetrics, expected)
 }
 
 func TestProcessBGPPeerDesc(t *testing.T) {
@@ -180,5 +149,40 @@ func TestProcessBGPPeerDesc(t *testing.T) {
 
 	if !reflect.DeepEqual(peerDesc, expectedOutput) {
 		t.Errorf("error comparing bgp neighbor description output: %v does not match expected %v", peerDesc, expectedOutput)
+	}
+}
+
+func TestProcessBGPNexthop(t *testing.T) {
+	expected := map[string]bgpNextHop{
+		"default": {
+			IPv4: map[string]bgpNextHopInterfaces{
+				"10.1.2.1": {
+					Nexthops: []struct {
+						InterfaceName string `json:"interfaceName"`
+					}{
+						{InterfaceName: "eth1"},
+					},
+				},
+				"10.2.2.1": {
+					Nexthops: []struct {
+						InterfaceName string `json:"interfaceName"`
+					}{
+						{InterfaceName: "eth2"},
+					},
+				},
+			},
+			IPv6: map[string]bgpNextHopInterfaces{},
+		},
+	}
+
+	input := readTestFixture(t, "show_ip_bgp_vrf_all_nexthop.json")
+
+	got, err := processBGPNexthop(input)
+	if err != nil {
+		t.Fatalf("processBGPNexthop returned error: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, expected) {
+		t.Errorf("processBGPNexthop() =\n%#v\nwant\n%#v", got, expected)
 	}
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,9 +1,16 @@
 package collector
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 )
 
 func readTestFixture(t *testing.T, filename string) []byte {
@@ -30,4 +37,39 @@ func compareMetrics(t *testing.T, gotMetrics map[string]float64, expectedMetrics
 			t.Errorf("missing metric: %s value %v", expectedMetricName, expectedMetricVal)
 		}
 	}
+}
+
+func collectMetrics(t *testing.T, ch <-chan prometheus.Metric) map[string]float64 {
+	got := make(map[string]float64)
+	re := regexp.MustCompile(`.*fqName: "(.*)", help:.*`)
+
+	for m := range ch {
+		var dtoM dto.Metric
+		if err := m.Write(&dtoM); err != nil {
+			t.Errorf("Write(): %v", err)
+			continue
+		}
+
+		// build label strings WITHOUT quotes
+		var lbls []string
+		for _, l := range dtoM.GetLabel() {
+			lbls = append(lbls, fmt.Sprintf("%s=%s", l.GetName(), l.GetValue()))
+		}
+		// sort them so the order is deterministic: area,iface,instance,vrf
+		sort.Strings(lbls)
+
+		// grab the numeric value
+		var v float64
+		if c := dtoM.GetCounter(); c != nil {
+			v = c.GetValue()
+		} else if g := dtoM.GetGauge(); g != nil {
+			v = g.GetValue()
+		}
+
+		// extract the metric name from the Desc() text
+		name := re.FindStringSubmatch(m.Desc().String())[1]
+		key := fmt.Sprintf("%s{%s}", name, strings.Join(lbls, ","))
+		got[key] = v
+	}
+	return got
 }

--- a/collector/ospf_test.go
+++ b/collector/ospf_test.go
@@ -1,14 +1,9 @@
 package collector
 
 import (
-	"fmt"
-	"regexp"
-	"sort"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 )
 
 // runOSPFTest is a one-stop helper.
@@ -44,41 +39,6 @@ func runOSPFTest(
 
 	got := collectMetrics(t, ch)
 	compareMetrics(t, got, expected)
-}
-
-func collectMetrics(t *testing.T, ch <-chan prometheus.Metric) map[string]float64 {
-	got := make(map[string]float64)
-	re := regexp.MustCompile(`.*fqName: "(.*)", help:.*`)
-
-	for m := range ch {
-		var dtoM dto.Metric
-		if err := m.Write(&dtoM); err != nil {
-			t.Errorf("Write(): %v", err)
-			continue
-		}
-
-		// build label strings WITHOUT quotes
-		var lbls []string
-		for _, l := range dtoM.GetLabel() {
-			lbls = append(lbls, fmt.Sprintf("%s=%s", l.GetName(), l.GetValue()))
-		}
-		// sort them so the order is deterministic: area,iface,instance,vrf
-		sort.Strings(lbls)
-
-		// grab the numeric value
-		var v float64
-		if c := dtoM.GetCounter(); c != nil {
-			v = c.GetValue()
-		} else if g := dtoM.GetGauge(); g != nil {
-			v = g.GetValue()
-		}
-
-		// extract the metric name from the Desc() text
-		name := re.FindStringSubmatch(m.Desc().String())[1]
-		key := fmt.Sprintf("%s{%s}", name, strings.Join(lbls, ","))
-		got[key] = v
-	}
-	return got
 }
 
 func TestProcessOSPFInterface(t *testing.T) {

--- a/collector/route.go
+++ b/collector/route.go
@@ -69,7 +69,14 @@ func (c *routeCollector) Update(ch chan<- prometheus.Metric) error {
 func processRouteSummaries(ch chan<- prometheus.Metric, jsonRoute []byte, afi string, routeDesc map[string]*prometheus.Desc) error {
 	var routeSummaries map[string]routeSummary
 	if err := json.Unmarshal(jsonRoute, &routeSummaries); err != nil {
-		return err
+		// fallback for older FRR versions that do not return the VRF key
+		var single routeSummary
+		if err2 := json.Unmarshal(jsonRoute, &single); err2 != nil {
+			return err2
+		}
+		routeSummaries = map[string]routeSummary{
+			"default": single,
+		}
 	}
 
 	for vrf, routeSummary := range routeSummaries {

--- a/collector/route.go
+++ b/collector/route.go
@@ -69,14 +69,7 @@ func (c *routeCollector) Update(ch chan<- prometheus.Metric) error {
 func processRouteSummaries(ch chan<- prometheus.Metric, jsonRoute []byte, afi string, routeDesc map[string]*prometheus.Desc) error {
 	var routeSummaries map[string]routeSummary
 	if err := json.Unmarshal(jsonRoute, &routeSummaries); err != nil {
-		// fallback for older FRR versions that do not return the VRF key
-		var single routeSummary
-		if err2 := json.Unmarshal(jsonRoute, &single); err2 != nil {
-			return err2
-		}
-		routeSummaries = map[string]routeSummary{
-			"default": single,
-		}
+		return err
 	}
 
 	for vrf, routeSummary := range routeSummaries {

--- a/collector/testdata/show_ip_bgp_vrf_all_nexthop.json
+++ b/collector/testdata/show_ip_bgp_vrf_all_nexthop.json
@@ -1,0 +1,41 @@
+{
+  "default":{
+    "ipv4":{
+      "10.1.2.1":{
+        "valid":true,
+        "complete":true,
+        "igpMetric":0,
+        "pathCount":0,
+        "peer":"10.1.2.1",
+        "resolvedPrefix":"10.1.2.0/24",
+        "nexthops":[
+          {
+            "interfaceName":"eth1"
+          }
+        ],
+        "lastUpdate":{
+          "epoch":1750342037,
+          "string":"Thu Jun 19 14:07:17 2025\n"
+        }
+      },
+      "10.2.2.1":{
+        "valid":true,
+        "complete":true,
+        "igpMetric":0,
+        "pathCount":0,
+        "peer":"10.2.2.1",
+        "resolvedPrefix":"10.2.2.0/24",
+        "nexthops":[
+          {
+            "interfaceName":"eth2"
+          }
+        ],
+        "lastUpdate":{
+          "epoch":1750342037,
+          "string":"Thu Jun 19 14:07:17 2025\n"
+        }
+      }
+    },
+    "ipv6":{}
+  }
+}


### PR DESCRIPTION
This PR adds the BGP nexthop peering interface.
That allows the detection on which physical interface the peering is currently running.

This change sits behind the `collector.bgp.next-hop-interface` flag.