### PR TITLE
OSPF collector support for nbrState field

### DIFF
--- a/collector/ospf.go
+++ b/collector/ospf.go
@@ -341,8 +341,16 @@ type vrfNeighbors struct {
 	Neighbors map[string][]ospfNeighbor
 }
 
+func GetOSPFState(nbrState, state string) string {
+	if nbrState != "" {
+		return nbrState
+	}
+	return state
+}
+
 type ospfNeighbor struct {
 	State         string `json:"state"`
+	NbrState      string `json:"nbrState"`
 	IfaceName     string `json:"ifaceName"`
 	LocalAddress  string `json:"localAddress"`
 	RemoteAddress string `json:"address"`
@@ -350,6 +358,7 @@ type ospfNeighbor struct {
 
 func (n *ospfNeighbor) UnmarshalJSON(data []byte) error {
 	var temp struct {
+		NbrState   string `json:"nbrState"`
 		State      string `json:"state"`
 		IfaceName  string `json:"ifaceName"`
 		LocalAddr  string `json:"localAddress"`
@@ -368,7 +377,7 @@ func (n *ospfNeighbor) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("cannot unmarshal ospf neighbor iface: %s", iface)
 	}
 
-	state := strings.Split(temp.State, "/")
+	state := strings.Split(GetOSPFState(temp.NbrState, temp.State), "/")
 	if len(state) > 0 {
 		n.State = state[0]
 	} else {

--- a/collector/testdata/show_ip_ospf_vrf_all_neighbors.json
+++ b/collector/testdata/show_ip_ospf_vrf_all_neighbors.json
@@ -5,7 +5,7 @@
         "neighbors": {
             "0.0.35.148": [
                 {
-                    "state": "Full/-",
+                    "nbrState": "Full/-",
                     "role": "DROther",
                     "ifaceName": "eth0:192.168.1.2",
                     "address": "192.168.1.3"
@@ -25,7 +25,7 @@
                     "address": "192.168.3.3"
                 },
                 {
-                    "state": "ExStart/-",
+                    "nbrState": "ExStart/-",
                     "role": "DROther",
                     "ifaceName": "eth1:192.168.4.2",
                     "address": "192.168.4.3"


### PR DESCRIPTION
FRR 9 and above uses `nbrState` instead of `state` in JSON output. This PR adds OSFP collector support for both `state` and `nbrState`.

Fixes https://github.com/tynany/frr_exporter/issues/137