### PR TITLE
Soften FRR version parsing

### DIFF
--- a/collector/status.go
+++ b/collector/status.go
@@ -76,7 +76,7 @@ func processStatusVersion(output []byte) (string, string, error) {
 	firstLine := lines[0]
 
 	// Extract version using regex: FRRouting VERSION (...)
-	versionRegex := regexp.MustCompile(`FRRouting ([0-9]+\.[0-9]+\.[0-9]+)`)
+	versionRegex := regexp.MustCompile(`FRRouting (\S+)`)
 	versionMatch := versionRegex.FindStringSubmatch(firstLine)
 	if len(versionMatch) < 2 {
 		return "", "", fmt.Errorf("could not extract version from: %s", firstLine)

--- a/collector/status_test.go
+++ b/collector/status_test.go
@@ -35,6 +35,25 @@ func TestProcessStatusVersion(t *testing.T) {
 	}
 }
 
+func TestProcessStatusVersionGit(t *testing.T) {
+	fixture := readTestFixture(t, "show_version_git.txt")
+
+	version, os, err := processStatusVersion(fixture)
+	if err != nil {
+		t.Errorf("error calling processStatusVersion: %s", err)
+	}
+
+	expectedVersion := "9.1_git"
+	if version != expectedVersion {
+		t.Errorf("expected version %s, got %s", expectedVersion, version)
+	}
+
+	expectedOS := "Linux(6.12.43-talos)"
+	if os != expectedOS {
+		t.Errorf("expected os %s, got %s", expectedOS, os)
+	}
+}
+
 func TestProcessStatusVersionWithMetrics(t *testing.T) {
 	fixture := readTestFixture(t, "show_version.txt")
 

--- a/collector/testdata/show_version_git.txt
+++ b/collector/testdata/show_version_git.txt
@@ -1,0 +1,4 @@
+FRRouting 9.1_git (router) on Linux(6.12.43-talos).
+Copyright 1996-2005 Kunihiro Ishiguro, et al.
+ configured with:
+     '--prefix=/usr' '--sbindir=/usr/lib/frr' '--sysconfdir=/etc/frr' '--libdir=/usr/lib' '--localstatedir=/var/run/frr' '--enable-rpki' '--enable-vtysh' '--enable-multipath=64' '--enable-vty-group=frrvty' '--enable-user=frr' '--enable-group=frr' '--enable-pcre2posix' '--enable-scripting' 'CC=gcc' 'CXX=g++'\n


### PR DESCRIPTION
Version information for FRR may contain git commit information if built from source.  Per source, it should not contain any spaces, so match all non-space characters for version.

fixes #142

ref: https://github.com/FRRouting/frr/blob/75e0727db9311200fe3eb9973a196b3c9bfc414b/lib/version.h.in#L31