### PR TITLE
Add support for sh ip route vrf json pre FRR 10.1 bug

### DIFF
--- a/collector/route.go
+++ b/collector/route.go
@@ -2,7 +2,9 @@ package collector
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/prometheus/client_golang/prometheus"
@@ -72,34 +74,85 @@ func processRouteSummaries(ch chan<- prometheus.Metric, jsonRoute []byte, afi st
 		// fallback for older FRR versions that do not return the VRF key
 		var single routeSummary
 		if err2 := json.Unmarshal(jsonRoute, &single); err2 != nil {
-			return err2
+			// fallback for pre-10.1.0 FRR with multiple VRFs where "vrf all"
+			// produces concatenated (invalid) JSON. Query each VRF individually.
+			return processRouteSummariesPerVRF(ch, afi, routeDesc)
 		}
 		routeSummaries = map[string]routeSummary{
 			"default": single,
 		}
 	}
 
-	for vrf, routeSummary := range routeSummaries {
-
-		// Total routes
-		newGauge(ch, routeDesc["total"], float64(routeSummary.RoutesTotal), afi, vrf)
-
-		// Total FIB routes
-		newGauge(ch, routeDesc["totalFib"], float64(routeSummary.RoutesTotalFib), afi, vrf)
-
-		if *detailedRoutes {
-			for _, route := range routeSummary.Routes {
-				labels := []string{afi, route.Type, vrf}
-
-				newGauge(ch, routeDesc["fibCount"], float64(route.Fib), labels...)
-				newGauge(ch, routeDesc["fibOffloadedCount"], float64(route.FibOffLoaded), labels...)
-				newGauge(ch, routeDesc["fibTrappedCount"], float64(route.FibTrapped), labels...)
-				newGauge(ch, routeDesc["ribCount"], float64(route.Rib), labels...)
-			}
-		}
+	for vrf, rs := range routeSummaries {
+		emitRouteSummaryMetrics(ch, rs, afi, vrf, routeDesc)
 	}
 
 	return nil
+}
+
+func processRouteSummariesPerVRF(ch chan<- prometheus.Metric, afi string, routeDesc map[string]*prometheus.Desc) error {
+	vrfs, err := getVRFs()
+	if err != nil {
+		return err
+	}
+
+	var cmdFmt string
+	if afi == "ipv4" {
+		cmdFmt = "show ip route vrf %s summary json"
+	} else {
+		cmdFmt = "show ipv6 route vrf %s summary json"
+	}
+
+	for _, vrf := range vrfs {
+		cmd := fmt.Sprintf(cmdFmt, vrf)
+		jsonRoute, err := executeZebraCommand(cmd)
+		if err != nil {
+			return err
+		}
+
+		var rs routeSummary
+		if err := json.Unmarshal(jsonRoute, &rs); err != nil {
+			return cmdOutputProcessError(cmd, string(jsonRoute), err)
+		}
+
+		emitRouteSummaryMetrics(ch, rs, afi, vrf, routeDesc)
+	}
+
+	return nil
+}
+
+func emitRouteSummaryMetrics(ch chan<- prometheus.Metric, rs routeSummary, afi string, vrf string, routeDesc map[string]*prometheus.Desc) {
+	newGauge(ch, routeDesc["total"], float64(rs.RoutesTotal), afi, vrf)
+	newGauge(ch, routeDesc["totalFib"], float64(rs.RoutesTotalFib), afi, vrf)
+
+	if *detailedRoutes {
+		for _, route := range rs.Routes {
+			labels := []string{afi, route.Type, vrf}
+			newGauge(ch, routeDesc["fibCount"], float64(route.Fib), labels...)
+			newGauge(ch, routeDesc["fibOffloadedCount"], float64(route.FibOffLoaded), labels...)
+			newGauge(ch, routeDesc["fibTrappedCount"], float64(route.FibTrapped), labels...)
+			newGauge(ch, routeDesc["ribCount"], float64(route.Rib), labels...)
+		}
+	}
+}
+
+func getVRFs() ([]string, error) {
+	output, err := executeZebraCommand("show vrf")
+	if err != nil {
+		return nil, err
+	}
+	return parseVRFs(output), nil
+}
+
+func parseVRFs(output []byte) []string {
+	vrfs := []string{"default"}
+	for _, line := range strings.Split(string(output), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "vrf" {
+			vrfs = append(vrfs, fields[1])
+		}
+	}
+	return vrfs
 }
 
 type routeSummary struct {

--- a/collector/route_test.go
+++ b/collector/route_test.go
@@ -1,13 +1,9 @@
 package collector
 
 import (
-	"fmt"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
 )
 
 var expectedRouteMetrics = map[string]float64{
@@ -77,75 +73,47 @@ var expectedRouteMetrics = map[string]float64{
 	"frr_route_total_fib{afi=ipv6,vrf=red}":                                    218322,
 }
 
+func TestParseVRFs(t *testing.T) {
+	fixture := readTestFixture(t, "show_vrf.txt")
+	got := parseVRFs(fixture)
+	expected := []string{"default", "vrf-red", "vrf-blue"}
+
+	if len(got) != len(expected) {
+		t.Fatalf("expected %d VRFs, got %d: %v", len(expected), len(got), got)
+	}
+	for i, v := range expected {
+		if got[i] != v {
+			t.Errorf("expected VRF[%d] = %q, got %q", i, v, got[i])
+		}
+	}
+}
+
+func TestParseVRFsEmpty(t *testing.T) {
+	fixture := readTestFixture(t, "show_vrf_empty.txt")
+	got := parseVRFs(fixture)
+	if len(got) != 1 || got[0] != "default" {
+		t.Errorf("expected [default], got %v", got)
+	}
+}
+
 func TestProcessRouteSummaries(t *testing.T) {
 	ch := make(chan prometheus.Metric, 1024)
 
 	enableDetailedRoutes := true
 	detailedRoutes = &enableDetailedRoutes
 
-	// Load test data for IPv4
 	jsonRouteIPv4 := readTestFixture(t, "show_ip_route_vrf_all_summary.json")
 	if err := processRouteSummaries(ch, jsonRouteIPv4, "ipv4", getRouteDesc()); err != nil {
-		t.Errorf("error calling processRouteSummaries ipv4: %s", err)
+		t.Fatalf("error calling processRouteSummaries ipv4: %s", err)
 	}
 
-	// Load test data for IPv6
 	jsonRouteIPv6 := readTestFixture(t, "show_ipv6_route_vrf_all_summary.json")
 	if err := processRouteSummaries(ch, jsonRouteIPv6, "ipv6", getRouteDesc()); err != nil {
-		t.Errorf("error calling processRouteSummaries ipv6: %s", err)
+		t.Fatalf("error calling processRouteSummaries ipv6: %s", err)
 	}
 
 	close(ch)
 
-	// Create a map of following format:
-	//   key: metric_name{labelname:labelvalue,...}
-	//   value: metric value
-	gotMetrics := make(map[string]float64)
-
-	for {
-		msg, more := <-ch
-		if !more {
-			break
-		}
-		metric := &dto.Metric{}
-		if err := msg.Write(metric); err != nil {
-			t.Errorf("error writing metric: %s", err)
-		}
-
-		var labels []string
-		for _, label := range metric.GetLabel() {
-			labels = append(labels, fmt.Sprintf("%s=%s", label.GetName(), label.GetValue()))
-		}
-
-		var value float64
-		if metric.GetCounter() != nil {
-			value = metric.GetCounter().GetValue()
-		} else if metric.GetGauge() != nil {
-			value = metric.GetGauge().GetValue()
-		}
-
-		re, err := regexp.Compile(`.*fqName: "(.*)", help:.*`)
-		if err != nil {
-			t.Errorf("could not compile regex: %s", err)
-		}
-		metricName := re.FindStringSubmatch(msg.Desc().String())[1]
-
-		gotMetrics[fmt.Sprintf("%s{%s}", metricName, strings.Join(labels, ","))] = value
-	}
-
-	for metricName, metricVal := range gotMetrics {
-		if expectedMetricVal, ok := expectedRouteMetrics[metricName]; ok {
-			if expectedMetricVal != metricVal {
-				t.Errorf("metric %s expected value %v got %v", metricName, expectedMetricVal, metricVal)
-			}
-		} else {
-			t.Errorf("unexpected metric: %s : %v", metricName, metricVal)
-		}
-	}
-
-	for expectedMetricName, expectedMetricVal := range expectedRouteMetrics {
-		if _, ok := gotMetrics[expectedMetricName]; !ok {
-			t.Errorf("missing metric: %s value %v", expectedMetricName, expectedMetricVal)
-		}
-	}
+	gotMetrics := collectMetrics(t, ch)
+	compareMetrics(t, gotMetrics, expectedRouteMetrics)
 }

--- a/collector/testdata/show_vrf.txt
+++ b/collector/testdata/show_vrf.txt
@@ -1,0 +1,2 @@
+vrf vrf-red id 4 table 10 (configured)
+vrf vrf-blue id 5 table 11 (configured)


### PR DESCRIPTION
# Background
This fixes a bug where FRR versions prior to 10.1 outputted concatenated (i.e. malformed) JSON for the `show ip route vrf all json` command. 

# Implementation
The `processRouteSummaries` function tries three strategies in order: VRF-keyed map -> single object -> per-VRF queries

# FRR Bug
From https://frrouting.org/release/10.1/

> Fix malformed json output for multiple vrfs in command show ip route vrf all json
Let me work on a fix.

# FRR Explorer Bugs
Fixes https://github.com/tynany/frr_exporter/issues/139