### PR TITLE
fix(dev): use VM user in lima-provision docker group setup

### DIFF
--- a/dev/Makefile
+++ b/dev/Makefile
@@ -308,7 +308,7 @@ lima-provision:
 	echo "Starting Docker:"
 	limactl shell $(LIMA_VM) -- sudo systemctl enable docker
 	limactl shell $(LIMA_VM) -- sudo systemctl start docker
-	limactl shell $(LIMA_VM) -- sudo usermod -aG docker $(shell whoami)
+	limactl shell $(LIMA_VM) -- sh -c 'sudo usermod -aG docker "$$(whoami)"'
 	@echo "Installing Go $(GO_VERSION):"
 	limactl shell $(LIMA_VM) -- curl -fsSL https://go.dev/dl/go$(GO_VERSION).linux-arm64.tar.gz -o /tmp/go.tar.gz
 	limactl shell $(LIMA_VM) -- sudo rm -rf /usr/local/go


### PR DESCRIPTION
# Problem
make lima-provision failed with:
```bash
usermod: user '<host-username>' does not exist
```

The lima-provision target used $(shell whoami) to get the username for adding to the docker group. This macro is evaluated by make on the host macOS, so it passes the host username (e.g. john.doe) to usermod inside the Lima VM. However, the Lima VM does not always have a user matching the host macOS username. When the host username is incompatible with Linux (e.g. contains a dot like john.doe), Lima cannot create a matching account and falls back to its default VM user (lima), causing a mismatch. As a result, usermod fails with "user does not exist".

# Fix
Evaluate whoami inside the VM at shell runtime instead:
```bash
# Before
limactl shell $(LIMA_VM) -- sudo usermod -aG docker $(shell whoami)

# After
limactl shell $(LIMA_VM) -- sh -c 'sudo usermod -aG docker "$$(whoami)"'
```

This ensures the correct VM-local user is added to the docker group regardless of what the host macOS username is.
