### PR TITLE
Version Support Missing OS

### DIFF
--- a/collector/status.go
+++ b/collector/status.go
@@ -83,13 +83,14 @@ func processStatusVersion(output []byte) (string, string, error) {
 	}
 	version := versionMatch[1]
 
-	// Extract OS using regex: on OS.
+	// Extract OS using regex: on OS. OS is optional as not all FRR
+	// distributions include it (e.g. Cumulus).
+	var os string
 	osRegex := regexp.MustCompile(`on (.+)\.$`)
 	osMatch := osRegex.FindStringSubmatch(firstLine)
-	if len(osMatch) < 2 {
-		return "", "", fmt.Errorf("could not extract OS from: %s", firstLine)
+	if len(osMatch) >= 2 {
+		os = osMatch[1]
 	}
-	os := osMatch[1]
 
 	return version, os, nil
 }

--- a/collector/status_test.go
+++ b/collector/status_test.go
@@ -71,6 +71,24 @@ func TestProcessStatusVersionWithMetrics(t *testing.T) {
 	compareMetrics(t, gotMetrics, expectedStatusMetrics)
 }
 
+func TestProcessStatusVersionNoOS(t *testing.T) {
+	fixture := readTestFixture(t, "show_version_no_os.txt")
+
+	version, os, err := processStatusVersion(fixture)
+	if err != nil {
+		t.Errorf("error calling processStatusVersion: %s", err)
+	}
+
+	expectedVersion := "7.5+cl5.2.0u0"
+	if version != expectedVersion {
+		t.Errorf("expected version %s, got %s", expectedVersion, version)
+	}
+
+	if os != "" {
+		t.Errorf("expected empty os, got %s", os)
+	}
+}
+
 func TestProcessStatusVersionEmpty(t *testing.T) {
 	_, _, err := processStatusVersion([]byte(""))
 	if err == nil {

--- a/collector/testdata/show_version_no_os.txt
+++ b/collector/testdata/show_version_no_os.txt
@@ -1,0 +1,2 @@
+FRRouting 7.5+cl5.2.0u0 (router).
+Copyright 1996-2005 Kunihiro Ishiguro, et al.


### PR DESCRIPTION
Problem: processStatusVersion returned an error when the OS couldn't be extracted from the `show version` output. Some FRR distributions (e.g., `Cumulus: FRRouting 7.5+cl5.2.0u0 (router)`)   don't include the on <OS> part, causing the collector to report version=unknown, os=unknown, status=0 even though FRR is up and the version is available.

Fixes https://github.com/tynany/frr_exporter/issues/157
