### PR TITLE
fix(bgp): lowercase AFI/SAFI in monitored-prefixes vty commands

### DIFF
--- a/collector/bgp.go
+++ b/collector/bgp.go
@@ -498,11 +498,11 @@ func getPeerPrefixPresence(ch chan<- prometheus.Metric, wg *sync.WaitGroup, AFI 
 
 	var cmdReceived, cmdAdvertised string
 	if strings.ToLower(vrfName) == "default" {
-		cmdReceived = fmt.Sprintf("show bgp  %s %s neighbors %s routes json", AFI, SAFI, neighbor)
-		cmdAdvertised = fmt.Sprintf("show bgp  %s %s neighbors %s advertised-routes json", AFI, SAFI, neighbor)
+		cmdReceived = fmt.Sprintf("show bgp  %s %s neighbors %s routes json", strings.ToLower(AFI), strings.ToLower(SAFI), neighbor)
+		cmdAdvertised = fmt.Sprintf("show bgp  %s %s neighbors %s advertised-routes json", strings.ToLower(AFI), strings.ToLower(SAFI), neighbor)
 	} else {
-		cmdReceived = fmt.Sprintf("show bgp vrf %s %s %s neighbors %s routes json", vrfName, AFI, SAFI, neighbor)
-		cmdAdvertised = fmt.Sprintf("show bgp vrf %s %s %s neighbors %s advertised-routes json", vrfName, AFI, SAFI, neighbor)
+		cmdReceived = fmt.Sprintf("show bgp vrf %s %s %s neighbors %s routes json", vrfName, strings.ToLower(AFI), strings.ToLower(SAFI), neighbor)
+		cmdAdvertised = fmt.Sprintf("show bgp vrf %s %s %s neighbors %s advertised-routes json", vrfName, strings.ToLower(AFI), strings.ToLower(SAFI), neighbor)
 	}
 
 	receivedOutput, err := executeBGPCommand(cmdReceived)


### PR DESCRIPTION
### Bug

`getPeerPrefixPresence()` (added in #151, v1.11.0) builds its vty commands by interpolating the SAFI verbatim from the `show bgp vrf all summary json` map key: `ipv4Unicast` -> `safiName[4:]` = `"Unicast"`. The resulting command is e.g.:

```
show bgp ipv4 Unicast neighbors <ip> routes json
```

bgpd rejects this with `% Unknown command`. Because the exporter talks to the raw daemon socket, the error response never satisfies the reader's termination condition, so each per-peer query blocks until the 20s socket read timeout:

```
err="read unix @->/var/run/frr/bgpd.vty: i/o timeout"
```

With one goroutine per peer x AFI/SAFI piling onto that timeout, every scrape of `/metrics` hangs and the exporter is effectively down whenever `--collector.bgp.monitored-prefixes` is enabled. (The socket layer hanging on `% Unknown command` instead of surfacing it is arguably a separate issue — this PR only fixes the command construction.)

### Repro

1. FRR host with established BGP peers, `frr_exporter` v1.11.0.
2. Run with `--collector.bgp --collector.bgp.monitored-prefixes=<file with any valid prefix>`.
3. `curl -m 5 localhost:9342/metrics` -> times out; log shows the `i/o timeout` errors above. Manually running `show bgp ipv4 Unicast neighbors <ip> routes json` in `vtysh` shows `% Unknown command`.

### Fix

Wrap `AFI`/`SAFI` in `strings.ToLower()` in the four `fmt.Sprintf` calls in `getPeerPrefixPresence()` (received + advertised, default and named VRF branches) — exactly matching what the sibling `getPeerAcceptedFilteredRoutes()` already does.

Verified live on a production FRR box: with the patch, `/metrics` returns promptly and `frr_bgp_peer_prefix_received` / `frr_bgp_peer_prefix_advertised` series are populated.

`gofmt` clean; `go vet ./...` and `go test ./...` pass.
